### PR TITLE
Fix test.unit script to run vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test.e2e": "cypress run",
-    "test.unit": "vitest",
+    "test.unit": "vitest run",
     "lint": "eslint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- run vitest using `vitest run` so unit tests exit automatically

## Testing
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_686df5bace608329bd521de79244ea2c