### PR TITLE
Fix ExploreContainer anchor CSS formatting

### DIFF
--- a/src/components/ExploreContainer.css
+++ b/src/components/ExploreContainer.css
@@ -20,4 +20,5 @@
 }
 
 #container a {
-  text-decoration: none;}
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- place closing brace of `#container a` selector on its own line

## Testing
- `npm run lint` *(fails: typescript-eslint/no-empty-object-type)*
- `npm run test.unit`
- `npm run test.e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686dffeb0ee08329aba562bef30158b6