### PR TITLE
Fix Cypress example braces

### DIFF
--- a/cypress/e2e/test.cy.ts
+++ b/cypress/e2e/test.cy.ts
@@ -1,5 +1,6 @@
 describe('My First Test', () => {
   it('Visits the app root url', () => {
-    cy.visit('/')
-    cy.contains('#container', 'Ready to create an app?')
-  })})
+    cy.visit('/');
+    cy.contains('#container', 'Ready to create an app?');
+  });
+});


### PR DESCRIPTION
## Summary
- split closing braces onto separate lines in the example Cypress test

## Testing
- `npm run lint` *(fails: typescript-eslint/no-empty-object-type)*
- `npm run test.unit`
- `npm run test.e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686dffebfcec832985637e86e05c5bb7