### PR TITLE
Add login and register pages with routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { Redirect, Route } from 'react-router-dom';
 import { IonApp, IonRouterOutlet, setupIonicReact } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import Home from './pages/Home';
+import Login from './pages/Login';
+import Register from './pages/Register';
 
 /* Core CSS required for Ionic components to work properly */
 import '@ionic/react/css/core.css';
@@ -41,6 +43,12 @@ const App: React.FC = () => (
       <IonRouterOutlet>
         <Route exact path="/home">
           <Home />
+        </Route>
+        <Route exact path="/login">
+          <Login />
+        </Route>
+        <Route exact path="/register">
+          <Register />
         </Route>
         <Route exact path="/">
           <Redirect to="/home" />

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,50 @@
+import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonButton, IonItem } from '@ionic/react';
+import { useHistory } from 'react-router-dom';
+import { useState } from 'react';
+
+const Login: React.FC = () => {
+  const history = useHistory();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    history.push('/home');
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Login</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <form onSubmit={handleSubmit}>
+          <IonItem>
+            <IonInput
+              label="Email"
+              value={email}
+              onIonChange={e => setEmail(e.detail.value!)}
+              required
+            />
+          </IonItem>
+          <IonItem>
+            <IonInput
+              type="password"
+              label="Password"
+              value={password}
+              onIonChange={e => setPassword(e.detail.value!)}
+              required
+            />
+          </IonItem>
+          <IonButton expand="block" type="submit">
+            Login
+          </IonButton>
+        </form>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Login;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,0 +1,50 @@
+import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonInput, IonButton, IonItem } from '@ionic/react';
+import { useHistory } from 'react-router-dom';
+import { useState } from 'react';
+
+const Register: React.FC = () => {
+  const history = useHistory();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    history.push('/home');
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Register</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <form onSubmit={handleSubmit}>
+          <IonItem>
+            <IonInput
+              label="Email"
+              value={email}
+              onIonChange={e => setEmail(e.detail.value!)}
+              required
+            />
+          </IonItem>
+          <IonItem>
+            <IonInput
+              type="password"
+              label="Password"
+              value={password}
+              onIonChange={e => setPassword(e.detail.value!)}
+              required
+            />
+          </IonItem>
+          <IonButton expand="block" type="submit">
+            Register
+          </IonButton>
+        </form>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default Register;


### PR DESCRIPTION
## Summary
- add Login and Register pages using Ionic form components
- route `/login` and `/register` in the main router
- submit each form to navigate to `/home`

## Testing
- `npm run lint`
- `npm run test.unit`
- `npm run test.e2e` *(fails: Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e98fa582c832991d5f6697b7e5971