### PR TITLE
Enable Capacitor Android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,22 @@ Make sure the dev server is running, then run Cypress:
 npm run test.e2e
 ```
 
+## Building an Android APK
+
+This project uses Capacitor to generate native Android binaries. To build an APK:
+
+1. Install **Android Studio** and ensure the Android SDK tools are available in your PATH.
+2. Build the web assets and sync them to the Android platform:
+
+   ```bash
+   npm run build.android
+   ```
+
+3. Open the Android project in Android Studio:
+
+   ```bash
+   npm run open.android
+   ```
+
+4. In Android Studio, use **Build > Build Bundle(s) / APK(s)** to create the APK.
+

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,10 @@
+import { CapacitorConfig } from '@capacitor/cli';
+
+const config: CapacitorConfig = {
+  appId: 'com.example.fiscalizacionapp',
+  appName: 'fiscalizacionApp',
+  webDir: 'dist',
+  bundledWebRuntime: false
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "preview": "vite preview",
     "test.e2e": "cypress run",
     "test.unit": "vitest run",
-    "lint": "eslint"
+    "lint": "eslint",
+    "sync": "cap sync",
+    "build.android": "npm run build && cap sync android",
+    "open.android": "cap open android"
   },
   "dependencies": {
     "@ionic/react": "^8.5.0",
@@ -20,7 +23,8 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-router": "^5.3.4",
-    "react-router-dom": "^5.3.4"
+    "react-router-dom": "^5.3.4",
+    "@capacitor/core": "^7.4.1"
   },
   "devDependencies": {
     "@testing-library/dom": ">=7.21.4",
@@ -42,7 +46,9 @@
     "typescript": "^5.1.6",
     "typescript-eslint": "^8.24.0",
     "vite": "~5.2.0",
-    "vitest": "^0.34.6"
+    "vitest": "^0.34.6",
+    "@capacitor/android": "^7.4.1",
+    "@capacitor/cli": "^7.4.1"
   },
   "description": "An Ionic project",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- integrate Capacitor to support generating Android builds
- add scripts for syncing and opening the Android project
- document how to create an APK

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_686eb729c6a883298f99af0db37fe3aa