### PR TITLE
Fix PrivateRoute typing

### DIFF
--- a/src/PrivateRoute.tsx
+++ b/src/PrivateRoute.tsx
@@ -3,7 +3,7 @@ import { Route, Redirect, RouteProps } from 'react-router-dom';
 import { useAuth } from './AuthContext';
 
 interface PrivateRouteProps extends RouteProps {
-  component: React.ComponentType<unknown>;
+  component: React.ComponentType<object>;
 }
 
 const PrivateRoute: React.FC<PrivateRouteProps> = ({ component: Component, ...rest }) => {


### PR DESCRIPTION
## Summary
- relax component typing in `PrivateRoute` to allow `React.FC` pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ee3f922088329a978a238b69ea547