### PR TITLE
Add DNI field to registration and update tests

### DIFF
--- a/cypress/e2e/flow.cy.ts
+++ b/cypress/e2e/flow.cy.ts
@@ -6,7 +6,8 @@ describe('Full Voting Flow', () => {
 
   it('registers a new user', () => {
     cy.visit('/register');
-    cy.get('input[ng-model], ion-input').first().type('testuser');
+    cy.get('ion-input').eq(0).type('testuser');
+    cy.get('ion-input').eq(1).type('12345678');
     cy.get('input[type="password"], ion-input[type="password"]').type('pass');
     cy.contains('button', 'Register').click();
     cy.url().should('include', '/login');
@@ -17,8 +18,8 @@ describe('Full Voting Flow', () => {
 
   it('logs in and completes flow', () => {
     cy.visit('/login');
-    cy.get('input').first().type('testuser');
-    cy.get('input[type="password"], ion-input[type="password"]').type('pass');
+    cy.get('ion-input').first().type('testuser');
+    cy.get('ion-input[type="password"]').type('pass');
     cy.contains('button', 'Login').click();
     cy.url().should('include', '/mesas');
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -9,7 +9,7 @@ const Login: React.FC = () => {
 
   const handleLogin = (e: React.FormEvent) => {
     e.preventDefault();
-    const users: { username: string; password: string }[] = JSON.parse(localStorage.getItem('users') || '[]');
+    const users: { username: string; dni: string; password: string }[] = JSON.parse(localStorage.getItem('users') || '[]');
     const user = users.find((u) => u.username === username && u.password === password);
     if (user) {
       localStorage.setItem('loggedIn', 'true');

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -5,12 +5,13 @@ import { useHistory } from 'react-router-dom';
 const Register: React.FC = () => {
   const history = useHistory();
   const [username, setUsername] = useState('');
+  const [dni, setDni] = useState('');
   const [password, setPassword] = useState('');
 
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     const users = JSON.parse(localStorage.getItem('users') || '[]');
-    users.push({ username, password });
+    users.push({ username, dni, password });
     localStorage.setItem('users', JSON.stringify(users));
     history.push('/login');
   };
@@ -27,6 +28,10 @@ const Register: React.FC = () => {
           <IonItem>
             <IonLabel position="stacked">Username</IonLabel>
             <IonInput value={username} onIonChange={e => setUsername(e.detail.value!)} required />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">DNI</IonLabel>
+            <IonInput value={dni} onIonChange={e => setDni(e.detail.value!)} required />
           </IonItem>
           <IonItem>
             <IonLabel position="stacked">Password</IonLabel>


### PR DESCRIPTION
## Summary
- add `dni` field to the registration page
- persist DNI in local storage
- adjust login to read user objects that include DNI
- update e2e flow test to cover new registration field

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: vitest not found)*
- `npm run test.e2e` *(fails: cypress not found)*
- `npm run build` *(fails: Cannot find module 'react' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686eeda00efc83298dbecda798b94c56