### PR TITLE
Add mesa setup flow and voter listing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Login from './pages/Login';
 import MesaSelection from './pages/MesaSelection';
 import VoteSubmission from './pages/VoteSubmission';
 import VoterDetails from './pages/VoterDetails';
+import VoterList from './pages/VoterList';
 import Escrutinio from './pages/Escrutinio';
 import VoterCount from './pages/VoterCount';
 import SelectMesa from './pages/SelectMesa';
@@ -54,6 +55,7 @@ const App: React.FC = () => (
             <Home />
           </Route>
           <PrivateRoute exact path="/select-mesa" component={SelectMesa} />
+          <PrivateRoute exact path="/voters" component={VoterList} />
           <Route exact path="/">
             <Redirect to="/home" />
           </Route>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -13,7 +13,7 @@ const Login: React.FC = () => {
     const user = users.find((u) => u.username === username && u.password === password);
     if (user) {
       localStorage.setItem('loggedIn', 'true');
-      history.push('/mesas');
+      history.push('/select-mesa');
     }
   };
 

--- a/src/pages/SelectMesa.tsx
+++ b/src/pages/SelectMesa.tsx
@@ -6,81 +6,72 @@ import {
   IonContent,
   IonItem,
   IonLabel,
-  IonSelect,
-  IonSelectOption,
+  IonInput,
   IonButton,
 } from '@ionic/react';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-const sessions = ['Mañana', 'Tarde', 'Noche'];
-const circuits = ['Circuito 1', 'Circuito 2', 'Circuito 3'];
-const mesas = ['Mesa 1', 'Mesa 2', 'Mesa 3'];
-
 const SelectMesa: React.FC = () => {
   const history = useHistory();
-  const [session, setSession] = useState<string>();
-  const [circuit, setCircuit] = useState<string>();
-  const [mesa, setMesa] = useState<string>();
+  const [seccion, setSeccion] = useState('');
+  const [circuito, setCircuito] = useState('');
+  const [mesa, setMesa] = useState('');
 
   const handleNext = () => {
-    history.push('/home');
+    localStorage.setItem('seccion', seccion);
+    localStorage.setItem('circuito', circuito);
+    localStorage.setItem('mesa', mesa);
+    history.push('/voters');
   };
 
   return (
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonTitle>Seleccionar Mesa</IonTitle>
+          <IonTitle>Configurar Mesa</IonTitle>
         </IonToolbar>
       </IonHeader>
       <IonContent className="ion-padding">
         <IonItem>
-          <IonLabel>Sesión</IonLabel>
-          <IonSelect
-            value={session}
-            placeholder="Seleccione sesión"
-            onIonChange={(e) => setSession(e.detail.value)}
-          >
-            {sessions.map((s) => (
-              <IonSelectOption key={s} value={s}>
-                {s}
-              </IonSelectOption>
-            ))}
-          </IonSelect>
+          <IonLabel position="stacked">Sección</IonLabel>
+          <IonInput
+            value={seccion}
+            inputmode="numeric"
+            maxlength={3}
+            onIonChange={(e) => setSeccion(e.detail.value ?? '')}
+          />
         </IonItem>
-
         <IonItem>
-          <IonLabel>Circuito</IonLabel>
-          <IonSelect
-            value={circuit}
-            placeholder="Seleccione circuito"
-            onIonChange={(e) => setCircuit(e.detail.value)}
-          >
-            {circuits.map((c) => (
-              <IonSelectOption key={c} value={c}>
-                {c}
-              </IonSelectOption>
-            ))}
-          </IonSelect>
+          <IonLabel position="stacked">Circuito</IonLabel>
+          <IonInput
+            value={circuito}
+            inputmode="numeric"
+            maxlength={3}
+            onIonChange={(e) => setCircuito(e.detail.value ?? '')}
+          />
         </IonItem>
-
         <IonItem>
-          <IonLabel>Mesa</IonLabel>
-          <IonSelect
+          <IonLabel position="stacked">Mesa</IonLabel>
+          <IonInput
             value={mesa}
-            placeholder="Seleccione mesa"
-            onIonChange={(e) => setMesa(e.detail.value)}
-          >
-            {mesas.map((m) => (
-              <IonSelectOption key={m} value={m}>
-                {m}
-              </IonSelectOption>
-            ))}
-          </IonSelect>
+            inputmode="numeric"
+            maxlength={4}
+            onIonChange={(e) => setMesa(e.detail.value ?? '')}
+          />
         </IonItem>
 
-        <IonButton expand="block" onClick={handleNext}>
+        <IonButton
+          expand="block"
+          onClick={handleNext}
+          disabled={
+            !(
+              seccion.length === 3 &&
+              circuito.length === 3 &&
+              mesa.length === 4
+            )
+          }
+        >
           Siguiente
         </IonButton>
       </IonContent>

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -1,0 +1,59 @@
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem,
+  IonLabel,
+} from '@ionic/react';
+import { useEffect, useState } from 'react';
+
+interface Voter {
+  numero_de_orden: string;
+  dni: string;
+  genero: string;
+}
+
+const SAMPLE_VOTERS: Voter[] = [
+  { numero_de_orden: '001', dni: '11111111', genero: 'M' },
+  { numero_de_orden: '002', dni: '22222222', genero: 'F' },
+];
+
+const VoterList: React.FC = () => {
+  const [voters, setVoters] = useState<Voter[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('voters');
+    if (stored) {
+      setVoters(JSON.parse(stored));
+    } else {
+      setVoters(SAMPLE_VOTERS);
+      localStorage.setItem('voters', JSON.stringify(SAMPLE_VOTERS));
+    }
+  }, []);
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Listado de Votantes</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent>
+        <IonList>
+          {voters.map((voter, index) => (
+            <IonItem key={index} lines="full">
+              <IonLabel>{voter.numero_de_orden}</IonLabel>
+              <IonLabel>{voter.dni}</IonLabel>
+              <IonLabel>{voter.genero}</IonLabel>
+            </IonItem>
+          ))}
+        </IonList>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default VoterList;


### PR DESCRIPTION
## Summary
- request mesa config after login
- persist seccion, circuito and mesa
- show configured voters list

## Testing
- `npm run lint`
- `npm run test.unit`
- `npm run test.e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_686ef093a7d48329b21f86e6de200f66