### PR TITLE
Refactor router outlet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,51 +51,37 @@ const App: React.FC = () => (
     <IonReactRouter>
       <AuthProvider>
         <IonRouterOutlet>
+          <Route exact path="/register">
+            <Register />
+          </Route>
+          <Route exact path="/login">
+            <Login />
+          </Route>
+          <Route exact path="/mesas">
+            <MesaSelection />
+          </Route>
+          <Route exact path="/vote">
+            <VoteSubmission />
+          </Route>
+          <Route exact path="/voter">
+            <VoterDetails />
+          </Route>
           <Route exact path="/home">
             <Home />
           </Route>
           <PrivateRoute exact path="/select-mesa" component={SelectMesa} />
           <PrivateRoute exact path="/voters" component={VoterList} />
+          <Route exact path="/escrutinio">
+            <Escrutinio />
+          </Route>
+          <Route exact path="/voter-count">
+            <VoterCount />
+          </Route>
           <Route exact path="/">
-            <Redirect to="/home" />
+            <Redirect to="/login" />
           </Route>
         </IonRouterOutlet>
       </AuthProvider>
-      <IonRouterOutlet>
-        <Route exact path="/register">
-          <Register />
-        </Route>
-        <Route exact path="/login">
-          <Login />
-        </Route>
-        <Route exact path="/mesas">
-          <MesaSelection />
-        </Route>
-        <Route exact path="/vote">
-          <VoteSubmission />
-        </Route>
-        <Route exact path="/voter">
-          <VoterDetails />
-        </Route>
-        <Route exact path="/home">
-          <Home />
-        </Route>
-        <Route exact path="/escrutinio">
-          <Escrutinio />
-        </Route>
-        <Route exact path="/voter-count">
-          <VoterCount />
-        </Route>
-        <Route exact path="/login">
-          <Login />
-        </Route>
-        <Route exact path="/register">
-          <Register />
-        </Route>
-        <Route exact path="/">
-          <Redirect to="/register" />
-        </Route>
-      </IonRouterOutlet>
     </IonReactRouter>
   </IonApp>
 );


### PR DESCRIPTION
## Summary
- simplify App router with a single `IonRouterOutlet`
- redirect `/` route to `/login`
- remove duplicate route declarations

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_686ef43b82108329ae1f3e23e6d9c918