### PR TITLE
Add MongoDB support and voter addition page

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint",
     "sync": "cap sync",
     "build.android": "npm run build && cap sync android",
-    "open.android": "cap open android"
+    "open.android": "cap open android",
+    "start:server": "node server/index.js"
   },
   "dependencies": {
     "@capacitor/core": "^7.4.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import voterRoutes from './routes/voters.js';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/fiscalizacion';
+mongoose.connect(MONGODB_URI);
+
+app.use('/api/voters', voterRoutes);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/models/VotanteEstablecimiento.js
+++ b/server/models/VotanteEstablecimiento.js
@@ -1,0 +1,26 @@
+import mongoose from 'mongoose';
+
+const personaSchema = new mongoose.Schema({
+  dni: String,
+  nombre: String,
+  apellido: String,
+});
+
+const personasVotantesSchema = new mongoose.Schema({
+  numero_de_orden: Number,
+  dni: String,
+  genero: String,
+});
+
+const votanteEstablecimientoSchema = new mongoose.Schema({
+  establecimiento: {
+    seccion: String,
+    circuito: String,
+    mesa: String,
+  },
+  persona: personaSchema,
+  personasVotantes: [personasVotantesSchema],
+  fechaEnviado: String,
+});
+
+export default mongoose.model('VotanteEstablecimiento', votanteEstablecimientoSchema);

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fiscalizacion-server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "express": "^4.19.2",
+    "mongoose": "^8.0.3",
+    "cors": "^2.8.5"
+  }
+}

--- a/server/routes/voters.js
+++ b/server/routes/voters.js
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import VotanteEstablecimiento from '../models/VotanteEstablecimiento.js';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  const voters = await VotanteEstablecimiento.find();
+  res.json(voters);
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const voter = new VotanteEstablecimiento(req.body);
+    await voter.save();
+    res.status(201).json(voter);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import MesaSelection from './pages/MesaSelection';
 import VoteSubmission from './pages/VoteSubmission';
 import VoterDetails from './pages/VoterDetails';
 import VoterList from './pages/VoterList';
+import AddVoter from './pages/AddVoter';
 import Escrutinio from './pages/Escrutinio';
 import VoterCount from './pages/VoterCount';
 import SelectMesa from './pages/SelectMesa';
@@ -71,6 +72,7 @@ const App: React.FC = () => (
           </Route>
           <PrivateRoute exact path="/select-mesa" component={SelectMesa} />
           <PrivateRoute exact path="/voters" component={VoterList} />
+          <PrivateRoute exact path="/add-voter" component={AddVoter} />
           <Route exact path="/escrutinio">
             <Escrutinio />
           </Route>

--- a/src/pages/AddVoter.tsx
+++ b/src/pages/AddVoter.tsx
@@ -1,0 +1,103 @@
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonItem,
+  IonLabel,
+  IonInput,
+  IonButton
+} from '@ionic/react';
+import { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+const AddVoter: React.FC = () => {
+  const history = useHistory();
+  const [seccion, setSeccion] = useState('');
+  const [circuito, setCircuito] = useState('');
+  const [mesa, setMesa] = useState('');
+  const [dni, setDni] = useState('');
+  const [nombre, setNombre] = useState('');
+  const [apellido, setApellido] = useState('');
+  const [orden, setOrden] = useState('');
+  const [votanteDni, setVotanteDni] = useState('');
+  const [genero, setGenero] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data = {
+      establecimiento: { seccion, circuito, mesa },
+      persona: { dni, nombre, apellido },
+      personasVotantes: [
+        {
+          numero_de_orden: parseInt(orden, 10) || 0,
+          dni: votanteDni,
+          genero
+        }
+      ],
+      fechaEnviado: new Date().toISOString()
+    };
+    await fetch('/api/voters', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    history.push('/voters');
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Agregar Votante</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <form onSubmit={handleSubmit}>
+          <IonItem>
+            <IonLabel position="stacked">Sección</IonLabel>
+            <IonInput value={seccion} onIonChange={e => setSeccion(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Circuito</IonLabel>
+            <IonInput value={circuito} onIonChange={e => setCircuito(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Mesa</IonLabel>
+            <IonInput value={mesa} onIonChange={e => setMesa(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">DNI</IonLabel>
+            <IonInput value={dni} onIonChange={e => setDni(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Nombre</IonLabel>
+            <IonInput value={nombre} onIonChange={e => setNombre(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Apellido</IonLabel>
+            <IonInput value={apellido} onIonChange={e => setApellido(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Número de Orden</IonLabel>
+            <IonInput value={orden} onIonChange={e => setOrden(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">DNI Votante</IonLabel>
+            <IonInput value={votanteDni} onIonChange={e => setVotanteDni(e.detail.value ?? '')} />
+          </IonItem>
+          <IonItem>
+            <IonLabel position="stacked">Género</IonLabel>
+            <IonInput value={genero} onIonChange={e => setGenero(e.detail.value ?? '')} />
+          </IonItem>
+          <IonButton expand="block" type="submit" className="ion-margin-top">
+            Guardar
+          </IonButton>
+        </form>
+      </IonContent>
+    </IonPage>
+  );
+};
+
+export default AddVoter;

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -7,31 +7,36 @@ import {
   IonList,
   IonItem,
   IonLabel,
+  IonButton
 } from '@ionic/react';
 import { useEffect, useState } from 'react';
 
 interface Voter {
-  numero_de_orden: string;
-  dni: string;
-  genero: string;
+  establecimiento: {
+    seccion: string;
+    circuito: string;
+    mesa: string;
+  };
+  persona: {
+    dni: string;
+    nombre: string;
+    apellido: string;
+  };
+  personasVotantes: {
+    numero_de_orden: number;
+    dni: string;
+    genero: string;
+  }[];
+  fechaEnviado: string;
 }
-
-const SAMPLE_VOTERS: Voter[] = [
-  { numero_de_orden: '001', dni: '11111111', genero: 'M' },
-  { numero_de_orden: '002', dni: '22222222', genero: 'F' },
-];
 
 const VoterList: React.FC = () => {
   const [voters, setVoters] = useState<Voter[]>([]);
 
   useEffect(() => {
-    const stored = localStorage.getItem('voters');
-    if (stored) {
-      setVoters(JSON.parse(stored));
-    } else {
-      setVoters(SAMPLE_VOTERS);
-      localStorage.setItem('voters', JSON.stringify(SAMPLE_VOTERS));
-    }
+    fetch('/api/voters')
+      .then((res) => res.json())
+      .then((data) => setVoters(data));
   }, []);
 
   return (
@@ -42,12 +47,20 @@ const VoterList: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent>
+        <IonButton routerLink="/add-voter" expand="block" className="ion-margin-bottom">
+          Agregar Votante
+        </IonButton>
         <IonList>
           {voters.map((voter, index) => (
             <IonItem key={index} lines="full">
-              <IonLabel>{voter.numero_de_orden}</IonLabel>
-              <IonLabel>{voter.dni}</IonLabel>
-              <IonLabel>{voter.genero}</IonLabel>
+              <IonLabel>
+                {voter.persona.nombre} {voter.persona.apellido} - {voter.persona.dni}
+              </IonLabel>
+              {voter.personasVotantes[0] && (
+                <IonLabel slot="end">
+                  {voter.personasVotantes[0].numero_de_orden}
+                </IonLabel>
+              )}
             </IonItem>
           ))}
         </IonList>


### PR DESCRIPTION
## Summary
- add Express/Mongoose backend under `server/`
- create `AddVoter` page with form to submit voter to backend
- fetch voter list from backend and add button to add voter
- register `/add-voter` route
- expose `start:server` script

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: vitest not found)*
- `npm run test.e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0805f9348329b8600bad2b86d216