### PR TITLE
Implement persistent mesa selection

### DIFF
--- a/src/pages/SelectMesa.tsx
+++ b/src/pages/SelectMesa.tsx
@@ -9,7 +9,7 @@ import {
   IonInput,
   IonButton,
 } from '@ionic/react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 const SelectMesa: React.FC = () => {
@@ -17,12 +17,30 @@ const SelectMesa: React.FC = () => {
   const [seccion, setSeccion] = useState('');
   const [circuito, setCircuito] = useState('');
   const [mesa, setMesa] = useState('');
+  const [editing, setEditing] = useState(true);
+
+  useEffect(() => {
+    const savedSeccion = localStorage.getItem('seccion');
+    const savedCircuito = localStorage.getItem('circuito');
+    const savedMesa = localStorage.getItem('mesa');
+    if (savedSeccion && savedCircuito && savedMesa) {
+      setSeccion(savedSeccion);
+      setCircuito(savedCircuito);
+      setMesa(savedMesa);
+      setEditing(false);
+    }
+  }, []);
 
   const handleNext = () => {
     localStorage.setItem('seccion', seccion);
     localStorage.setItem('circuito', circuito);
     localStorage.setItem('mesa', mesa);
+    setEditing(false);
     history.push('/voters');
+  };
+
+  const handleModify = () => {
+    setEditing(true);
   };
 
   return (
@@ -39,6 +57,7 @@ const SelectMesa: React.FC = () => {
             value={seccion}
             inputmode="numeric"
             maxlength={3}
+            disabled={!editing}
             onIonChange={(e) => setSeccion(e.detail.value ?? '')}
           />
         </IonItem>
@@ -48,6 +67,7 @@ const SelectMesa: React.FC = () => {
             value={circuito}
             inputmode="numeric"
             maxlength={3}
+            disabled={!editing}
             onIonChange={(e) => setCircuito(e.detail.value ?? '')}
           />
         </IonItem>
@@ -57,10 +77,16 @@ const SelectMesa: React.FC = () => {
             value={mesa}
             inputmode="numeric"
             maxlength={4}
+            disabled={!editing}
             onIonChange={(e) => setMesa(e.detail.value ?? '')}
           />
         </IonItem>
 
+        {!editing && (
+          <IonButton expand="block" onClick={handleModify}>
+            Modificar
+          </IonButton>
+        )}
         <IonButton
           expand="block"
           onClick={handleNext}


### PR DESCRIPTION
## Summary
- reload selected mesa values from localStorage after login
- allow editing saved mesa values with a new `Modificar` button
- keep form inputs read-only until `Modificar` is pressed
- navigate to voter list after saving mesa configuration

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f0ef9c7588329b78299d448ca5230