### PR TITLE
Add layout component for all pages

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonButtons,
+  IonButton,
+  IonFooter
+} from '@ionic/react';
+import { useAuth } from '../AuthContext';
+
+interface LayoutProps {
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+}
+
+const Layout: React.FC<LayoutProps> = ({ children, footer }) => {
+  const { logout } = useAuth();
+
+  return (
+    <IonPage className="flex flex-col min-h-screen">
+      <IonHeader className="bg-primary-500 text-white">
+        <IonToolbar className="flex justify-between items-center px-4">
+          <IonTitle className="font-bold text-lg">Fiscalizacion App</IonTitle>
+          <IonButtons slot="end">
+            <IonButton color="light" onClick={logout}>Logout</IonButton>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      {children}
+      {footer && <IonFooter>{footer}</IonFooter>}
+    </IonPage>
+  );
+};
+
+export default Layout;

--- a/src/pages/AddVoter.tsx
+++ b/src/pages/AddVoter.tsx
@@ -1,14 +1,11 @@
 import {
-  IonPage,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
   IonInput,
   IonButton
 } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -42,12 +39,7 @@ const AddVoter: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Agregar Votante</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <form onSubmit={handleSubmit}>
           <IonItem>
@@ -83,7 +75,7 @@ const AddVoter: React.FC = () => {
           </IonButton>
         </form>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -1,8 +1,4 @@
 import {
-  IonPage,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
@@ -10,6 +6,7 @@ import {
   IonButton,
   IonText
 } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState } from 'react';
 
 interface ResultadoEscrutinio {
@@ -38,12 +35,7 @@ const Escrutinio: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Escrutinio</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <IonItem>
           <IonLabel position="stacked">Lista 100</IonLabel>
@@ -86,7 +78,7 @@ const Escrutinio: React.FC = () => {
           </IonText>
         )}
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,21 +1,12 @@
-import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar, IonButton } from '@ionic/react';
+import { IonContent, IonButton } from '@ionic/react';
+import Layout from '../components/Layout';
 import ExploreContainer from '../components/ExploreContainer';
 import './Home.css';
 
 const Home: React.FC = () => {
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Blank</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent fullscreen>
-        <IonHeader collapse="condense">
-          <IonToolbar>
-            <IonTitle size="large">Blank</IonTitle>
-          </IonToolbar>
-        </IonHeader>
         <ExploreContainer />
         <IonButton routerLink="/escrutinio" expand="block" className="ion-margin-top">
           Ir a Escrutinio
@@ -24,7 +15,7 @@ const Home: React.FC = () => {
           Go to Voter Count
         </IonButton>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,8 +1,4 @@
 import {
-  IonPage,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
@@ -10,6 +6,7 @@ import {
   IonButton,
   IonList
 } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
@@ -36,12 +33,7 @@ const Login: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Login</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <form onSubmit={handleLogin}>
           <IonList>
@@ -76,7 +68,7 @@ const Login: React.FC = () => {
           REGISTER
         </IonButton>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/MesaSelection.tsx
+++ b/src/pages/MesaSelection.tsx
@@ -1,4 +1,5 @@
-import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonList, IonItem } from '@ionic/react';
+import { IonContent, IonList, IonItem } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useHistory } from 'react-router-dom';
 
 const mesas = [1, 2, 3];
@@ -10,12 +11,7 @@ const MesaSelection: React.FC = () => {
     history.push('/vote');
   };
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Mesas</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent>
         <IonList>
           {mesas.map(id => (
@@ -25,7 +21,7 @@ const MesaSelection: React.FC = () => {
           ))}
         </IonList>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,4 +1,5 @@
-import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonItem, IonLabel, IonInput, IonButton } from '@ionic/react';
+import { IonContent, IonItem, IonLabel, IonInput, IonButton } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -17,12 +18,7 @@ const Register: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Register</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <form onSubmit={handleRegister}>
           <IonItem>
@@ -43,7 +39,7 @@ const Register: React.FC = () => {
           Login
         </IonButton>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/SelectMesa.tsx
+++ b/src/pages/SelectMesa.tsx
@@ -1,14 +1,11 @@
 import {
-  IonPage,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
   IonContent,
   IonItem,
   IonLabel,
   IonInput,
   IonButton,
 } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -44,12 +41,7 @@ const SelectMesa: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Configurar Mesa</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <IonItem>
           <IonLabel position="stacked">Sección</IonLabel>
@@ -101,7 +93,7 @@ const SelectMesa: React.FC = () => {
           Siguiente
         </IonButton>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/VoteSubmission.tsx
+++ b/src/pages/VoteSubmission.tsx
@@ -1,4 +1,5 @@
-import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonItem, IonLabel, IonSelect, IonSelectOption, IonButton } from '@ionic/react';
+import { IonContent, IonItem, IonLabel, IonSelect, IonSelectOption, IonButton } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -13,12 +14,7 @@ const VoteSubmission: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Vote</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <form onSubmit={handleSubmit}>
           <IonItem>
@@ -31,7 +27,7 @@ const VoteSubmission: React.FC = () => {
           <IonButton expand="block" type="submit" className="ion-margin-top">Submit Vote</IonButton>
         </form>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/VoterCount.tsx
+++ b/src/pages/VoterCount.tsx
@@ -1,14 +1,11 @@
 import {
   IonButton,
   IonContent,
-  IonHeader,
   IonInput,
   IonItem,
   IonLabel,
-  IonPage,
-  IonTitle,
-  IonToolbar,
 } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState } from 'react';
 
 const VoterCount: React.FC = () => {
@@ -23,12 +20,7 @@ const VoterCount: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Voter Count</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <IonItem>
           <IonLabel position="stacked">Session</IonLabel>
@@ -71,7 +63,7 @@ const VoterCount: React.FC = () => {
           Save
         </IonButton>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/VoterDetails.tsx
+++ b/src/pages/VoterDetails.tsx
@@ -1,4 +1,5 @@
-import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonItem, IonLabel, IonInput, IonButton } from '@ionic/react';
+import { IonContent, IonItem, IonLabel, IonInput, IonButton } from '@ionic/react';
+import Layout from '../components/Layout';
 import { useState } from 'react';
 
 const VoterDetails: React.FC = () => {
@@ -12,12 +13,7 @@ const VoterDetails: React.FC = () => {
   };
 
   return (
-    <IonPage>
-      <IonHeader>
-        <IonToolbar>
-          <IonTitle>Voter Details</IonTitle>
-        </IonToolbar>
-      </IonHeader>
+    <Layout>
       <IonContent className="ion-padding">
         <form onSubmit={handleSubmit}>
           <IonItem>
@@ -31,7 +27,7 @@ const VoterDetails: React.FC = () => {
           <IonButton expand="block" type="submit" className="ion-margin-top">Save Details</IonButton>
         </form>
       </IonContent>
-    </IonPage>
+    </Layout>
   );
 };
 

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -1,6 +1,4 @@
 import {
-  IonPage,
-  IonHeader,
   IonToolbar,
   IonTitle,
   IonContent,
@@ -12,10 +10,10 @@ import {
   IonFooter,
   IonIcon
 } from '@ionic/react';
+import Layout from '../components/Layout';
 import { add, remove, create } from 'ionicons/icons';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import { useAuth } from '../AuthContext';
 
 interface Voter {
   establecimiento?: {
@@ -39,7 +37,6 @@ interface Voter {
 const VoterList: React.FC = () => {
   const [voters, setVoters] = useState<Voter[]>([]);
   const history = useHistory();
-  const { logout } = useAuth();
 
   const handleEndVoting = () => {
     history.push('/escrutinio');
@@ -49,11 +46,6 @@ const VoterList: React.FC = () => {
     history.push('/select-mesa');
   };
 
-  const handleLogout = () => {
-    logout();
-    history.push('/login');
-  };
-
   useEffect(() => {
     fetch('/api/voters')
       .then((res) => res.json())
@@ -61,19 +53,23 @@ const VoterList: React.FC = () => {
   }, []);
 
   return (
-    <IonPage>
-      <IonHeader>
+    <Layout
+      footer={
         <IonToolbar>
-          <IonButtons slot="start">
-            <IonButton onClick={handleEndVoting}>Terminar Votación</IonButton>
-          </IonButtons>
-          <IonTitle>Listado de Votantes</IonTitle>
-          <IonButtons slot="end">
-            <IonButton onClick={handleConfig}>Configurar</IonButton>
-            <IonButton onClick={handleLogout}>Cerrar Sesión</IonButton>
+          <IonButtons>
+            <IonButton routerLink="/add-voter">
+              <IonIcon icon={add} />
+            </IonButton>
+            <IonButton>
+              <IonIcon icon={remove} />
+            </IonButton>
+            <IonButton>
+              <IonIcon icon={create} />
+            </IonButton>
           </IonButtons>
         </IonToolbar>
-      </IonHeader>
+      }
+    >
       <IonContent>
         <IonList>
           {voters.map((voter, index) => (
@@ -91,22 +87,7 @@ const VoterList: React.FC = () => {
           ))}
         </IonList>
       </IonContent>
-      <IonFooter>
-        <IonToolbar>
-          <IonButtons>
-            <IonButton routerLink="/add-voter">
-              <IonIcon icon={add} />
-            </IonButton>
-            <IonButton>
-              <IonIcon icon={remove} />
-            </IonButton>
-            <IonButton>
-              <IonIcon icon={create} />
-            </IonButton>
-          </IonButtons>
-        </IonToolbar>
-      </IonFooter>
-    </IonPage>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a reusable `<Layout>` wrapper with Tailwind styling
- use `<Layout>` in each routed page
- remove old per-page headers

## Testing
- `npm run test.unit` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686f12d458d083298bddbfe3f3bdf6b2