### PR TITLE
Add API base URL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ npm run dev
 
 The app will be available at [http://localhost:5173](http://localhost:5173).
 
+### API server
+
+Start the Express API with:
+
+```bash
+npm run start:server
+```
+
+By default it listens on port `3000` as defined in `server/index.js`.
+
+You can point the frontend to a different API by setting `VITE_API_URL`:
+
+```bash
+VITE_API_URL=http://myhost:3000 npm run dev
+```
+
 ## Linting
 
 Run ESLint to analyze the project:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+

--- a/src/pages/AddVoter.tsx
+++ b/src/pages/AddVoter.tsx
@@ -7,6 +7,7 @@ import { Button, Input } from '../components';
 import { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import Layout from '../components/Layout';
+import { API_BASE_URL } from '../config';
 
 const AddVoter: React.FC = () => {
   const history = useHistory();
@@ -29,7 +30,7 @@ const AddVoter: React.FC = () => {
       ],
       fechaEnviado: new Date().toISOString()
     };
-    await fetch('/api/voters', {
+    await fetch(`${API_BASE_URL}/api/voters`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -16,6 +16,7 @@ import { Button } from '../components';
 import { add, remove, create } from 'ionicons/icons';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { API_BASE_URL } from '../config';
 
 interface Voter {
   establecimiento?: {
@@ -42,7 +43,7 @@ const VoterList: React.FC = () => {
   const history = useHistory();
 
   const loadVoters = () => {
-    fetch('/api/voters')
+    fetch(`${API_BASE_URL}/api/voters`)
       .then((res) => res.json())
       .then((data) => setVoters(data));
   };


### PR DESCRIPTION
## Summary
- add `src/config.ts` with configurable API URL
- use `API_BASE_URL` in voter pages
- document how to run the API server and override `VITE_API_URL`

## Testing
- `npm run lint` *(fails: "IonHeader" is defined but never used)*
- `npm run test.unit`

------
https://chatgpt.com/codex/tasks/task_e_686f2a86edc883298d9c6ef4f4f687db