### PR TITLE
Handle POST errors in AddVoter page

### DIFF
--- a/src/pages/AddVoter.test.tsx
+++ b/src/pages/AddVoter.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import AddVoter from './AddVoter';
+import { AuthProvider } from '../AuthContext';
+
+describe('AddVoter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('redirects to /voters on successful submit', async () => {
+    const history = createMemoryHistory({ initialEntries: ['/add-voter'] });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+
+    const { container } = render(
+      <AuthProvider>
+        <Router history={history}>
+          <AddVoter />
+        </Router>
+      </AuthProvider>
+    );
+
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(history.location.pathname).toBe('/voters');
+  });
+
+  test('shows alert on failure and stays on page', async () => {
+    const history = createMemoryHistory({ initialEntries: ['/add-voter'] });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, statusText: 'Bad' }));
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    const { container } = render(
+      <AuthProvider>
+        <Router history={history}>
+          <AddVoter />
+        </Router>
+      </AuthProvider>
+    );
+
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    await waitFor(() => expect(window.alert).toHaveBeenCalledWith('Bad'));
+    expect(history.location.pathname).toBe('/add-voter');
+  });
+});

--- a/src/pages/AddVoter.tsx
+++ b/src/pages/AddVoter.tsx
@@ -29,12 +29,20 @@ const AddVoter: React.FC = () => {
       ],
       fechaEnviado: new Date().toISOString()
     };
-    await fetch('/api/voters', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    });
-    history.push('/voters');
+    try {
+      const res = await fetch('/api/voters', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (!res.ok) {
+        alert(res.statusText || 'Error al guardar votante');
+        return;
+      }
+      history.push('/voters');
+    } catch {
+      alert('Error al guardar votante');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- show an alert when the POST request to create a voter fails
- only redirect to the list page on success
- cover success and failure cases in AddVoter unit tests

## Testing
- `npm run test.unit`
- `npm run lint` *(fails: various unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_686f2a8b310c83299433b1168f293fc5