### PR TITLE
Switch server from Mongo to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,19 @@ import { Button, Input, Card } from './src/components';
 ```
 
 Use them in pages instead of raw `IonButton` or `IonInput` for a consistent look.
+
+## Backend API
+
+The Express API now uses **SQLite** for data persistence. The database file
+`server/data.db` is created automatically when starting the server.
+
+Install the backend dependencies and run the server:
+
+```bash
+cd server
+npm install
+cd ..
+npm run start:server
+```
+
+This will initialize the database tables and serve the API on port `3000`.

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,42 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dbPath = path.join(__dirname, 'data.db');
+const db = new Database(dbPath);
+
+db.prepare(`CREATE TABLE IF NOT EXISTS mesas (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  seccion TEXT,
+  circuito TEXT,
+  mesa TEXT
+)`).run();
+
+db.prepare(`CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE,
+  password TEXT
+)`).run();
+
+db.prepare(`CREATE TABLE IF NOT EXISTS votantes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  seccion TEXT,
+  circuito TEXT,
+  mesa TEXT,
+  dni TEXT,
+  nombre TEXT,
+  apellido TEXT,
+  numero_de_orden INTEGER,
+  genero TEXT,
+  fechaEnviado TEXT
+)`).run();
+
+db.prepare(`CREATE TABLE IF NOT EXISTS escrutinio (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  mesa_id INTEGER,
+  datos TEXT,
+  FOREIGN KEY(mesa_id) REFERENCES mesas(id)
+)`).run();
+
+export default db;

--- a/server/index.js
+++ b/server/index.js
@@ -1,16 +1,19 @@
 import express from 'express';
-import mongoose from 'mongoose';
 import cors from 'cors';
+import './db.js';
 import voterRoutes from './routes/voters.js';
+import mesaRoutes from './routes/mesas.js';
+import userRoutes from './routes/users.js';
+import escrutinioRoutes from './routes/escrutinio.js';
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/fiscalizacion';
-mongoose.connect(MONGODB_URI);
-
 app.use('/api/voters', voterRoutes);
+app.use('/api/mesas', mesaRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/escrutinio', escrutinioRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "express": "^4.19.2",
-    "mongoose": "^8.0.3",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "better-sqlite3": "^9.0.0"
   }
 }

--- a/server/routes/escrutinio.js
+++ b/server/routes/escrutinio.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import db from '../db.js';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  const results = db.prepare('SELECT * FROM escrutinio').all();
+  res.json(results);
+});
+
+router.post('/', (req, res) => {
+  const { mesa_id, datos } = req.body;
+  const info = db
+    .prepare('INSERT INTO escrutinio (mesa_id, datos) VALUES (?, ?)')
+    .run(mesa_id, datos);
+  res.status(201).json({ id: info.lastInsertRowid });
+});
+
+export default router;

--- a/server/routes/mesas.js
+++ b/server/routes/mesas.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import db from '../db.js';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  const mesas = db.prepare('SELECT * FROM mesas').all();
+  res.json(mesas);
+});
+
+router.post('/', (req, res) => {
+  const { seccion, circuito, mesa } = req.body;
+  const info = db
+    .prepare('INSERT INTO mesas (seccion, circuito, mesa) VALUES (?, ?, ?)')
+    .run(seccion, circuito, mesa);
+  res.status(201).json({ id: info.lastInsertRowid });
+});
+
+export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import db from '../db.js';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  const users = db.prepare('SELECT * FROM users').all();
+  res.json(users);
+});
+
+router.post('/', (req, res) => {
+  const { username, password } = req.body;
+  const info = db
+    .prepare('INSERT INTO users (username, password) VALUES (?, ?)')
+    .run(username, password);
+  res.status(201).json({ id: info.lastInsertRowid });
+});
+
+export default router;

--- a/server/routes/voters.js
+++ b/server/routes/voters.js
@@ -1,21 +1,40 @@
 import { Router } from 'express';
-import VotanteEstablecimiento from '../models/VotanteEstablecimiento.js';
+import db from '../db.js';
 
 const router = Router();
 
-router.get('/', async (req, res) => {
-  const voters = await VotanteEstablecimiento.find();
+router.get('/', (req, res) => {
+  const voters = db.prepare('SELECT * FROM votantes').all();
   res.json(voters);
 });
 
-router.post('/', async (req, res) => {
-  try {
-    const voter = new VotanteEstablecimiento(req.body);
-    await voter.save();
-    res.status(201).json(voter);
-  } catch (err) {
-    res.status(400).json({ error: err.message });
-  }
+router.post('/', (req, res) => {
+  const {
+    seccion,
+    circuito,
+    mesa,
+    dni,
+    nombre,
+    apellido,
+    numero_de_orden,
+    genero,
+    fechaEnviado,
+  } = req.body;
+  const stmt = db.prepare(`INSERT INTO votantes (
+    seccion, circuito, mesa, dni, nombre, apellido, numero_de_orden, genero, fechaEnviado
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+  const info = stmt.run(
+    seccion,
+    circuito,
+    mesa,
+    dni,
+    nombre,
+    apellido,
+    numero_de_orden,
+    genero,
+    fechaEnviado,
+  );
+  res.status(201).json({ id: info.lastInsertRowid });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- replace mongoose with `better-sqlite3`
- set up database initializer
- convert voter routes to SQL
- add routes for mesas, users and escrutinio
- document new SQLite backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: vitest not found)*
- `npm run test.e2e` *(fails: cypress not found)*
- `npm install` in `server` and `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_686f30c29a04832990d17f84d1ba18b4