### PR TITLE
Send escrutinio to backend

### DIFF
--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -22,15 +22,32 @@ const Escrutinio: React.FC = () => {
   const [recurrido, setRecurrido] = useState('');
   const [resultado, setResultado] = useState<ResultadoEscrutinio | null>(null);
 
-  const handleSubmit = () => {
-    const data: ResultadoEscrutinio = {
+  const handleSubmit = async () => {
+    const datos: ResultadoEscrutinio = {
       lista100: parseInt(lista100, 10) || 0,
       votoEnBlanco: parseInt(votoEnBlanco, 10) || 0,
       nulo: parseInt(nulo, 10) || 0,
       recurrido: parseInt(recurrido, 10) || 0
     };
-    setResultado(data);
-    console.log('Resultado enviado', data);
+    setResultado(datos);
+    const mesaId = Number(localStorage.getItem('mesaId'));
+    try {
+      const res = await fetch('/api/escrutinio', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mesa_id: mesaId,
+          datos: JSON.stringify(datos)
+        })
+      });
+      if (res.ok) {
+        alert('Escrutinio enviado correctamente');
+      } else {
+        alert(res.statusText || 'Error al enviar escrutinio');
+      }
+    } catch {
+      alert('Error al enviar escrutinio');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- post vote totals from `Escrutinio` page to `/api/escrutinio`
- show alert confirming submission or reporting failure

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f33b05d748329bc500d82b319c00a