### PR TITLE
Fix VoterList persona null errors

### DIFF
--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -90,7 +90,7 @@ const VoterList: React.FC = () => {
           {voters.map((voter, index) => (
             <IonItem key={index} lines="full">
               <IonLabel>
-                {voter.persona.nombre} {voter.persona.apellido}
+                {voter.persona?.nombre ?? ''} {voter.persona?.apellido ?? ''}
                 {voter.personasVotantes[0]?.dni && ` - ${voter.personasVotantes[0].dni}`}
               </IonLabel>
               {voter.personasVotantes[0] && (
@@ -126,7 +126,7 @@ const VoterList: React.FC = () => {
             >
               <div>
                 <div className="font-medium">
-                  {voter.persona.nombre} {voter.persona.apellido}
+                  {voter.persona?.nombre ?? ''} {voter.persona?.apellido ?? ''}
                 </div>
                 <div className="text-sm text-gray-500">
                   {voter.personasVotantes[0]?.dni || '-'}


### PR DESCRIPTION
## Summary
- guard against missing `persona` data when rendering voters

## Testing
- `npm run lint` *(fails: Unexpected any and unused-vars)*
- `npm run test.unit` *(fails: cannot find package 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_686f3d9aa2c083298eb914f1fa3cf93d