### PR TITLE
Hide Tailwind dev overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Ionic App" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.tailwindcss.com" data-mode="build"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- disable Tailwind play CDN overlay by setting `data-mode="build"` on the CDN script tag

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68706a0433f48329b61afa24c590e556