### PR TITLE
Add back navigation prop to Layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,20 +8,30 @@ import {
   IonButton,
   IonFooter
 } from '@ionic/react';
+import { useHistory } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
 interface LayoutProps {
   children: React.ReactNode;
   footer?: React.ReactNode;
+  backHref?: string;
 }
 
-const Layout: React.FC<LayoutProps> = ({ children, footer }) => {
+const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
   const { logout } = useAuth();
+  const history = useHistory();
 
   return (
     <IonPage className="flex flex-col min-h-screen">
       <IonHeader className="bg-primary-500 text-white">
         <IonToolbar className="flex justify-between items-center px-4">
+          {backHref && (
+            <IonButtons slot="start">
+              <IonButton color="light" onClick={() => history.push(backHref)}>
+                Back
+              </IonButton>
+            </IonButtons>
+          )}
           <IonTitle className="font-bold text-lg">Fiscalizacion App</IonTitle>
           <IonButtons slot="end">
             <IonButton color="light" onClick={logout}>Logout</IonButton>

--- a/src/pages/AddVoter.tsx
+++ b/src/pages/AddVoter.tsx
@@ -51,7 +51,7 @@ const AddVoter: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout backHref="/voters">
       <IonContent className="ion-padding">
         <form onSubmit={handleSubmit}>
           <IonItem>

--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -51,7 +51,7 @@ const Escrutinio: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout backHref="/voters">
       <IonContent className="ion-padding">
         <IonItem>
           <IonLabel position="stacked">Lista 100</IonLabel>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -19,7 +19,7 @@ const Register: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout backHref="/login">
       <IonContent className="ion-padding">
         <form onSubmit={handleRegister}>
           <IonItem>

--- a/src/pages/SelectMesa.tsx
+++ b/src/pages/SelectMesa.tsx
@@ -40,7 +40,7 @@ const SelectMesa: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout backHref="/login">
       <IonContent className="ion-padding">
         <IonItem>
           <IonLabel position="stacked">Sección</IonLabel>

--- a/src/pages/VoteSubmission.tsx
+++ b/src/pages/VoteSubmission.tsx
@@ -15,7 +15,7 @@ const VoteSubmission: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout backHref="/mesas">
       <IonContent className="ion-padding">
         <form onSubmit={handleSubmit}>
           <IonItem>

--- a/src/pages/VoterCount.tsx
+++ b/src/pages/VoterCount.tsx
@@ -15,7 +15,7 @@ const VoterCount: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout backHref="/home">
       <IonContent className="ion-padding">
         <IonItem>
           <IonLabel position="stacked">Session</IonLabel>

--- a/src/pages/VoterDetails.tsx
+++ b/src/pages/VoterDetails.tsx
@@ -14,7 +14,7 @@ const VoterDetails: React.FC = () => {
   };
 
   return (
-    <Layout>
+    <Layout backHref="/vote">
       <IonContent className="ion-padding">
         <form onSubmit={handleSubmit}>
           <IonItem>

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -95,7 +95,7 @@ const VoterList: React.FC = () => {
   }, []);
 
   return (
-    <Layout>
+    <Layout backHref="/select-mesa">
       <IonHeader>
         <IonToolbar>
           <IonButtons slot="start">


### PR DESCRIPTION
## Summary
- add optional `backHref` prop to `Layout`
- add back buttons to pages via new prop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: missing packages like @tailwindcss/postcss, dexie)*
- `npm run test.e2e` *(fails: missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_6871930c5d1c8329b8a87a57eb7bab94