### PR TITLE
Improve back button visibility

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,8 +6,10 @@ import {
   IonTitle,
   IonButtons,
   IonButton,
-  IonFooter
+  IonFooter,
+  IonIcon
 } from '@ionic/react';
+import { chevronBackOutline } from 'ionicons/icons';
 import { useHistory } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 
@@ -27,7 +29,12 @@ const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
         <IonToolbar className="flex justify-between items-center px-4">
           {backHref && (
             <IonButtons slot="start">
-              <IonButton color="light" onClick={() => history.push(backHref)}>
+              <IonButton
+                color="light"
+                className="font-semibold"
+                onClick={() => history.push(backHref)}
+              >
+                <IonIcon icon={chevronBackOutline} slot="start" />
                 Back
               </IonButton>
             </IonButtons>


### PR DESCRIPTION
## Summary
- add icon and font weight to back button for better visibility

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test.unit` *(fails: vitest not found)*
- `npm run test.e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b8665f58832983fa344099e396dd