### PR TITLE
Add end-of-voting photo capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@capacitor/camera": "^5.0.6",
         "@ionic/react": "^8.5.0",
         "@ionic/react-router": "^8.5.0",
         "@types/react-router": "^5.1.20",
@@ -1636,6 +1637,25 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capacitor/camera": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@capacitor/camera/-/camera-5.0.10.tgz",
+      "integrity": "sha512-DOLYjiaOdUQk8mtAAgliqVVJaGegC7VzV4Tk3j1rjXyuc8JeX5SJOfow4v0N+NYxyGMsEEtwNnVZ1B7yzxsrVg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
+    },
+    "node_modules/@capacitor/core": {
+      "version": "5.7.8",
+      "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-5.7.8.tgz",
+      "integrity": "sha512-rrZcm/2vJM0WdWRQup1TUidbjQV9PfIadSkV4rAGLD7R6PuzZSMPGT0gmoZzCRlXkqrazrWWDkurei3ozU02FA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-router": "^5.3.4",
-    "react-router-dom": "^5.3.4"
+    "react-router-dom": "^5.3.4",
+    "@capacitor/camera": "^5.0.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@ionic/react';
 import { Button } from '../components';
 import Layout from '../components/Layout';
+import { Camera, CameraResultType } from '@capacitor/camera';
 import { add, remove, create } from 'ionicons/icons';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -66,7 +67,18 @@ const VoterList: React.FC = () => {
 };
 
 
-  const handleEndVoting = () => {
+  const handleEndVoting = async () => {
+    try {
+      const photo = await Camera.getPhoto({
+        resultType: CameraResultType.DataUrl,
+        quality: 80,
+      });
+      if (photo?.dataUrl) {
+        localStorage.setItem('endVotingPhoto', photo.dataUrl);
+      }
+    } catch (err) {
+      console.error('Error taking photo', err);
+    }
     history.push('/escrutinio');
   };
 


### PR DESCRIPTION
## Summary
- add Capacitor camera dependency
- capture a photo when the voting session ends

## Testing
- `npm run lint`
- `npm run test.unit` *(fails: 2 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6886b634bd948329a12b8b430ba3b2bc