### PR TITLE
Add login endpoint

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -16,4 +16,16 @@ router.post('/', (req, res) => {
   res.status(201).json({ id: info.lastInsertRowid });
 });
 
+router.post('/login', (req, res) => {
+  const { dni, password } = req.body;
+  const user = db
+    .prepare('SELECT * FROM users WHERE dni = ? AND password = ?')
+    .get(dni, password);
+  if (user) {
+    res.json(user);
+  } else {
+    res.status(401).json({ error: 'Invalid credentials' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- add a `/login` route in `server/routes/users.js`
- check `dni` and `password` against the SQLite `users` table

## Testing
- `npm run test.unit` *(fails: Not implemented: window.alert)*

------
https://chatgpt.com/codex/tasks/task_e_688bf1fb845c8329b23252305502632a