### PR TITLE
Switch auth to backend API

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -8,6 +8,17 @@ router.get('/', (req, res) => {
   res.json(users);
 });
 
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = db
+    .prepare('SELECT * FROM users WHERE username = ? AND password = ?')
+    .get(username, password);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  res.json({ id: user.id, username: user.username });
+});
+
 router.post('/', (req, res) => {
   const { username, password } = req.body;
   const info = db

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,17 +1,13 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import {
-  signInWithEmailAndPassword,
-  createUserWithEmailAndPassword,
-  signOut,
-  onAuthStateChanged,
-  User,
-} from 'firebase/auth';
-import { auth } from './firebase';
+
+export interface UserInfo {
+  dni: string;
+}
 
 export interface AuthContextType {
-  user: User | null;
+  user: UserInfo | null;
   login: (dni: string, password: string) => Promise<void>;
-  register: (email: string, password: string) => Promise<void>;
+  register: (dni: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   isAuthenticated: boolean;
 }
@@ -19,28 +15,52 @@ export interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
+  const [user, setUser] = useState<UserInfo | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   useEffect(() => {
-    const unsub = onAuthStateChanged(auth, current => {
-      setUser(current);
-      setIsAuthenticated(!!current);
-    });
-    return unsub;
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      setUser(JSON.parse(stored));
+      setIsAuthenticated(true);
+    }
   }, []);
 
   const login = async (dni: string, password: string) => {
-    const email = `${dni}@fake.com`;
-    await signInWithEmailAndPassword(auth, email, password);
+    const res = await fetch('/api/users/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: dni, password }),
+    });
+    if (!res.ok) {
+      throw new Error('Login failed');
+    }
+    const data = await res.json();
+    const info = { dni: data.username } as UserInfo;
+    setUser(info);
+    setIsAuthenticated(true);
+    localStorage.setItem('user', JSON.stringify(info));
   };
 
-  const register = async (email: string, password: string) => {
-    await createUserWithEmailAndPassword(auth, email, password);
+  const register = async (dni: string, password: string) => {
+    const res = await fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: dni, password }),
+    });
+    if (!res.ok) {
+      throw new Error('Register failed');
+    }
+    const info = { dni } as UserInfo;
+    setUser(info);
+    setIsAuthenticated(true);
+    localStorage.setItem('user', JSON.stringify(info));
   };
 
   const logout = async () => {
-    await signOut(auth);
+    setUser(null);
+    setIsAuthenticated(false);
+    localStorage.removeItem('user');
   };
 
   return (

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -15,7 +15,7 @@ const Register: React.FC = () => {
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await register(email, password);
+      await register(dni, password);
       history.push('/login');
     } catch (err: unknown) {
       console.error('Error al registrarse:', err);


### PR DESCRIPTION
## Summary
- add login endpoint in Express server
- rework `AuthContext` to fetch login/register and store user info locally
- adapt registration page to use new API

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run test.unit` *(fails: 2 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_688bf202e6e88329a7fe6f5b5408f56f