### PR TITLE
Add Google login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ npm run dev
 
 The app will be available at [http://localhost:5173](http://localhost:5173).
 
+## Firebase configuration
+
+Copy `.env.example` to `.env` and add your Firebase project keys:
+
+```bash
+cp .env.example .env
+# edit .env
+```
+
+Enable the **Google** sign-in provider in the Firebase console under
+**Authentication › Sign-in method**.
+
 ## Linting
 
 Run ESLint to analyze the project:

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import bcrypt from 'bcryptjs';
+import { signInWithPopup, GoogleAuthProvider, UserInfo } from 'firebase/auth';
+import { auth } from './firebase';
 
 
 export interface AuthContextType {
@@ -7,6 +9,7 @@ export interface AuthContextType {
   login: (dni: string, password: string) => Promise<void>;
   register: (email: string, dni: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
+  loginWithGoogle: () => Promise<void>;
   isAuthenticated: boolean;
 }
 
@@ -41,6 +44,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     localStorage.setItem('user', JSON.stringify(info));
   };
 
+  const loginWithGoogle = async () => {
+    const result = await signInWithPopup(auth, new GoogleAuthProvider());
+    const info = result.user as UserInfo;
+    setUser(info);
+    setIsAuthenticated(true);
+    localStorage.setItem('user', JSON.stringify(info));
+  };
+
   const register = async (dni: string, password: string) => {
     const hashed = bcrypt.hashSync(password, 10);
     const res = await fetch('/api/users', {
@@ -62,7 +73,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout, isAuthenticated }}>
+    <AuthContext.Provider value={{ user, login, register, logout, loginWithGoogle, isAuthenticated }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,7 +15,7 @@ import Layout from '../components/Layout';
 
 const Login: React.FC = () => {
   const history = useHistory();
-  const { login } = useAuth();
+  const { login, loginWithGoogle } = useAuth();
   const [dni, setDni] = useState('');
   const [password, setPassword] = useState('');
 
@@ -60,6 +60,14 @@ const Login: React.FC = () => {
           </IonList>
           <Button expand="block" type="submit" className="ion-margin-top">
             INGRESAR
+          </Button>
+          <Button
+            expand="block"
+            type="button"
+            onClick={loginWithGoogle}
+            className="ion-margin-top"
+          >
+            INGRESAR CON GOOGLE
           </Button>
         </form>
         <Button

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -13,3 +13,16 @@ window.matchMedia = window.matchMedia || function() {
       removeListener: function() {}
   };
 };
+
+// Prevent Firebase from initializing during tests
+import { vi } from 'vitest';
+
+vi.mock('firebase/app', () => ({
+  initializeApp: () => ({}),
+}));
+
+vi.mock('firebase/auth', () => ({
+  getAuth: () => ({}) ,
+  signInWithPopup: vi.fn(),
+  GoogleAuthProvider: class {},
+}));


### PR DESCRIPTION
## Summary
- allow Google-based authentication
- update login page with Google button
- document Firebase env vars
- prevent Firebase init during tests

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_688c05d7e6dc8329a9a293af571172e2