### PR TITLE
Fix user listing to use SQLite

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -3,9 +3,8 @@ import db from '../db.js';
 
 const router = Router();
 
-router.get('/', async (req, res) => {
-  const snapshot = await db.collection('users').get();
-  const users = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }));
+router.get('/', (req, res) => {
+  const users = db.prepare('SELECT * FROM users').all();
   res.json(users);
 });
 


### PR DESCRIPTION
## Summary
- replace the old Firestore call in the users route with a SQLite query

## Testing
- `npm run test.unit`

------
https://chatgpt.com/codex/tasks/task_e_688c05d9b7ec832993d5655ddd96f493