### PR TITLE
Remove Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Copy `.env.example` to `.env` and add your Firebase project keys:
 cp .env.example .env
 # edit .env
 ```
-
-Enable the **Google** sign-in provider in the Firebase console under
-**Authentication › Sign-in method**.
-
 ## Linting
 
 Run ESLint to analyze the project:

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,7 +15,7 @@ import Layout from '../components/Layout';
 
 const Login: React.FC = () => {
   const history = useHistory();
-  const { login, loginWithGoogle } = useAuth();
+  const { login } = useAuth();
   const [dni, setDni] = useState('');
   const [password, setPassword] = useState('');
 
@@ -60,14 +60,6 @@ const Login: React.FC = () => {
           </IonList>
           <Button expand="block" type="submit" className="ion-margin-top">
             INGRESAR
-          </Button>
-          <Button
-            expand="block"
-            type="button"
-            onClick={loginWithGoogle}
-            className="ion-margin-top"
-          >
-            INGRESAR CON GOOGLE
           </Button>
         </form>
         <Button

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -22,7 +22,5 @@ vi.mock('firebase/app', () => ({
 }));
 
 vi.mock('firebase/auth', () => ({
-  getAuth: () => ({}) ,
-  signInWithPopup: vi.fn(),
-  GoogleAuthProvider: class {},
+  getAuth: () => ({})
 }));


### PR DESCRIPTION
## Summary
- drop Google sign-in instructions from README
- remove `loginWithGoogle` button in `Login` page
- trim Google auth mock from test setup

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_688c294390348329b276f38bb707b74a