### PR TITLE
Align AuthContext register signature

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -9,7 +9,7 @@ export interface UserInfo {
 export interface AuthContextType {
   user: UserInfo | null;
   login: (dni: string, password: string) => Promise<void>;
-  register: (dni: string, password: string) => Promise<void>;
+  register: (email: string, dni: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   isAuthenticated: boolean;
 }


### PR DESCRIPTION
## Summary
- update `AuthContextType` so `register` accepts `(email, dni, password)`
- ensure registration page already calls `register(email, dni, password)`

## Testing
- `npm run test.unit`

------
https://chatgpt.com/codex/tasks/task_e_688c29447e908329a12e7bc7c506ad0d