### PR TITLE
Implement Firestore-based auth

### DIFF
--- a/server/firebase/index.js
+++ b/server/firebase/index.js
@@ -1,8 +1,14 @@
 import { initializeApp, applicationDefault } from 'firebase-admin/app';
 import { getFirestore } from 'firebase-admin/firestore';
 
+// Initialize Firebase Admin using default credentials so the server can
+// access Firestore. In a real deployment the credentials should be provided
+// through environment configuration or a service account key.
 initializeApp({
   credential: applicationDefault(),
 });
 
+// Export the Firestore instance as `db` and a convenience reference to the
+// `users` collection used throughout the API routes.
 export const db = getFirestore();
+export const usersCollection = db.collection('users');

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,30 +1,56 @@
 import { Router } from 'express';
-import db from '../db.js';
+import bcrypt from 'bcryptjs';
+import { usersCollection } from '../firebase/index.js';
 
 const router = Router();
 
-router.get('/', (req, res) => {
-  const users = db.prepare('SELECT * FROM users').all();
-  res.json(users);
-});
-
-router.post('/', (req, res) => {
-  const { username, password } = req.body; // password already hashed
-  const info = db
-    .prepare('INSERT INTO users (username, password) VALUES (?, ?)')
-    .run(username, password);
-  res.status(201).json({ id: info.lastInsertRowid });
-});
-
-router.post('/login', (req, res) => {
-  const { username, password } = req.body; // password is already hashed
-  const user = db
-    .prepare('SELECT * FROM users WHERE username = ?')
-    .get(username);
-  if (!user || user.password !== password) {
-    return res.status(401).json({ error: 'Invalid credentials' });
+// Fetch all users - primarily for development/testing purposes.
+router.get('/', async (req, res) => {
+  try {
+    const snapshot = await usersCollection.get();
+    const users = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch users' });
   }
-  res.json({ id: username, username });
+});
+
+// Register a new user. The password is hashed before storing to Firestore.
+router.post('/', async (req, res) => {
+  const { email, dni, password } = req.body;
+  if (!email || !dni || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  try {
+    const passwordHash = await bcrypt.hash(password, 10);
+    await usersCollection.doc(dni).set({ email, dni, passwordHash });
+    res.status(201).json({ id: dni });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to create user' });
+  }
+});
+
+// Login route. Verify the dni exists and the password matches the stored hash.
+router.post('/login', async (req, res) => {
+  const { dni, password } = req.body;
+  if (!dni || !password) {
+    return res.status(400).json({ error: 'Missing credentials' });
+  }
+  try {
+    const doc = await usersCollection.doc(dni).get();
+    if (!doc.exists) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const user = doc.data();
+    const valid = await bcrypt.compare(password, user.passwordHash);
+    if (!valid) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    res.json({ email: user.email, dni });
+  } catch (err) {
+    res.status(500).json({ error: 'Login failed' });
+  }
 });
 
 export default router;
+

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
-import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut } from 'firebase/auth';
-import { auth } from './firebase'; // Asegurate de tener este archivo correctamente configurado
+
 
 export interface UserInfo {
   dni: string;
@@ -9,7 +8,7 @@ export interface UserInfo {
 export interface AuthContextType {
   user: UserInfo | null;
   login: (dni: string, password: string) => Promise<void>;
-  register: (dni: string, password: string) => Promise<void>;
+  register: (email: string, dni: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   isAuthenticated: boolean;
 }
@@ -29,13 +28,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const login = async (dni: string, password: string) => {
-    const email = `${dni}@fake.com`;
     try {
-      await signInWithEmailAndPassword(auth, email, password);
-      const info = { dni };
-      setUser(info);
+      const res = await fetch('/api/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dni, password })
+      });
+      if (!res.ok) {
+        throw new Error('Usuario o clave incorrectos');
+      }
+      const info = await res.json();
+      setUser({ dni: info.dni });
       setIsAuthenticated(true);
-      localStorage.setItem('user', JSON.stringify(info));
+      localStorage.setItem('user', JSON.stringify({ dni: info.dni }));
     } catch (error) {
       console.error('Error en login:', error);
       throw new Error('Usuario o clave incorrectos');
@@ -43,22 +48,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const register = async (email: string, dni: string, password: string) => {
-  try {
-    await createUserWithEmailAndPassword(auth, email, password);
-    // Podés guardar el dni aparte si lo necesitás en localStorage:
-    const info = { dni };
-    setUser(info);
-    setIsAuthenticated(true);
-    localStorage.setItem('user', JSON.stringify(info));
-  } catch (error) {
-    console.error('Error en registro:', error);
-    throw new Error('No se pudo registrar');
-  }
-};
+    try {
+      const res = await fetch('/api/users', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, dni, password })
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'No se pudo registrar');
+      }
+      const info = { dni };
+      setUser(info);
+      setIsAuthenticated(true);
+      localStorage.setItem('user', JSON.stringify(info));
+    } catch (error) {
+      console.error('Error en registro:', error);
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error('No se pudo registrar');
+    }
+  };
 
 
   const logout = async () => {
-    await signOut(auth);
+    // There is no server session to invalidate, simply clear local data.
     setUser(null);
     setIsAuthenticated(false);
     localStorage.removeItem('user');

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,7 +15,7 @@ import Layout from '../components/Layout';
 
 const Login: React.FC = () => {
   const history = useHistory();
-  const { login, loginWithGoogle } = useAuth();
+  const { login } = useAuth();
   const [dni, setDni] = useState('');
   const [password, setPassword] = useState('');
 
@@ -60,14 +60,6 @@ const Login: React.FC = () => {
           </IonList>
           <Button expand="block" type="submit" className="ion-margin-top">
             INGRESAR
-          </Button>
-          <Button
-            expand="block"
-            type="button"
-            onClick={loginWithGoogle}
-            className="ion-margin-top"
-          >
-            INGRESAR CON GOOGLE
           </Button>
         </form>
         <Button


### PR DESCRIPTION
## Summary
- query Firestore from the server
- store users with hashed passwords
- verify login credentials against Firestore
- call new `/api/users` endpoints in the auth context
- clean up login screen

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_688c29466e9c8329b86b349cf7560a41