### PR TITLE
Update Vite proxy target

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   ],
   server: {
     proxy: {
-      '/api': 'http://localhost:5173',
+      '/api': 'http://localhost:3000',
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- point `/api` proxy to the Express server on port 3000

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_688c294782c88329b4072dc68a0631e5