### PR TITLE
Remove unused login helper and clarify backend auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ curl -X POST http://localhost:3000/api/users \
 ```
 
 After registering, log in on the `/login` page of the app using the same
-DNI and password.
+DNI and password. The login and register pages send credentials to the
+Express API (`/api/users/login` and `/api/users`) instead of using Firebase
+authentication.
 
 Passwords for users are now hashed using **bcryptjs**. Any existing entries in
 the `users` table that stored plaintext passwords will no longer work for

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -1,6 +1,0 @@
-import { signInWithEmailAndPassword } from 'firebase/auth';
-import { auth } from '../firebase';
-
-export const login = async (email: string, password: string) => {
-  return signInWithEmailAndPassword(auth, email, password);
-};


### PR DESCRIPTION
## Summary
- delete obsolete Firebase login helper
- clarify in README that login and registration use the Express backend

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_688d5cad44dc832982f353d62b9f2335