### PR TITLE
Use Firebase auth for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,48 +89,16 @@ import { Button, Input, Card } from './src/components';
 
 Use them in pages instead of raw `IonButton` or `IonInput` for a consistent look.
 
-## Backend API
+## User authentication
 
-The Express API now uses **SQLite** for data persistence. The database file
-`server/data.db` is created automatically when starting the server.
+User accounts are now handled directly through **Firebase Authentication**. The
+old Express backend is no longer required.
 
-Install the backend dependencies and start the server:
+### Registering and logging in
 
-```bash
-cd server
-npm install
-```
-
-The API stores user accounts in Firestore using Firebase Admin. Set the
-`GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of your
-service account JSON file before starting the server:
-
-```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
-node index.js
-```
-
-This initializes the database tables and serves the API on port `3000`.
-
-### User registration and login
-
-New users register by sending their **DNI** and a password to the `/api/users`
-endpoint:
-
-```bash
-curl -X POST http://localhost:3000/api/users \
-  -H 'Content-Type: application/json' \
-  -d '{"username":"12345678","password":"secret"}'
-```
-
-After registering, log in on the `/login` page of the app using the same
-DNI and password. The login and register pages send credentials to the
-Express API (`/api/users/login` and `/api/users`) instead of using Firebase
-authentication.
-
-Passwords for users are now hashed using **bcryptjs**. Any existing entries in
-the `users` table that stored plaintext passwords will no longer work for
-authentication. Delete those rows or recreate the database after updating.
+Create an account on the **Register** page using your email, DNI and password.
+Then sign in on the **Login** page with the same email and password. The app
+communicates only with Firebase for these operations.
 
 ## Local database
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,13 +16,13 @@ import Layout from '../components/Layout';
 const Login: React.FC = () => {
   const history = useHistory();
   const { login } = useAuth();
-  const [dni, setDni] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await login(dni, password);
+      await login(email, password);
       history.push('/select-mesa');
     } catch (err) {
       console.error(err);
@@ -41,10 +41,11 @@ const Login: React.FC = () => {
         <form onSubmit={handleLogin}>
           <IonList>
             <IonItem>
-              <IonLabel position="floating">DNI</IonLabel>
+              <IonLabel position="floating">Email</IonLabel>
               <Input
-                value={dni}
-                onIonChange={(e) => setDni(e.detail.value!)}
+                type="email"
+                value={email}
+                onIonChange={(e) => setEmail(e.detail.value!)}
                 required
               />
             </IonItem>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,11 +10,6 @@ export default defineConfig({
     react(),
     legacy()
   ],
-  server: {
-    proxy: {
-      '/api': 'http://localhost:3000',
-    },
-  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Summary
- replace API login/register with Firebase auth
- persist Firebase user info in localStorage
- remove backend proxy from Vite config
- update login page to request email instead of DNI
- document new Firebase-only auth flow

## Testing
- `npm run lint`
- `npm run test.unit`
- `npm run dev` *(fails: connection blocked?)*

------
https://chatgpt.com/codex/tasks/task_e_688d6abe8b008329ab631f8df47273bc