### PR TITLE
feat: add firestore database

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,4 +14,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+export const db = getFirestore(app);
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -24,3 +24,7 @@ vi.mock('firebase/app', () => ({
 vi.mock('firebase/auth', () => ({
   getAuth: () => ({})
 }));
+
+vi.mock('firebase/firestore', () => ({
+  getFirestore: () => ({})
+}));


### PR DESCRIPTION
## Summary
- connect to Firestore with a shared db instance
- mock Firestore in test setup to avoid real initialization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_688e47f403a48329a48dcd501814902f