### PR TITLE
refactor(auth): remove backend sync from register

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -104,18 +104,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       } catch (error) {
         console.error('Error guardando usuario en Firestore:', error);
       }
-      try {
-        await fetch('/api/users', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email, dni, password }),
-        });
-      } catch (error) {
-        console.error('Error sincronizando usuario en backend:', error);
-      }
       setUser(info);
       setIsAuthenticated(true);
       localStorage.setItem('user', JSON.stringify(info));
+      return;
     } catch (error) {
       console.error('Error en registro:', error);
       if (error instanceof Error) {


### PR DESCRIPTION
## Summary
- drop unnecessary `/api/users` sync in `register`
- return early after persisting user to Firestore and local state

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_688fc03beb5483299671fa126f516138