### PR TITLE
feat(server): add voto column to votantes table

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -29,7 +29,8 @@ db.prepare(`CREATE TABLE IF NOT EXISTS votantes (
   apellido TEXT,
   numero_de_orden INTEGER,
   genero TEXT,
-  fechaEnviado TEXT
+  fechaEnviado TEXT,
+  voto INTEGER DEFAULT 0
 )`).run();
 
 db.prepare(`CREATE TABLE IF NOT EXISTS escrutinio (

--- a/server/migrations/add-voto-column.js
+++ b/server/migrations/add-voto-column.js
@@ -1,0 +1,11 @@
+import db from '../db.js';
+
+const columns = db.prepare("PRAGMA table_info(votantes)").all();
+const hasVoto = columns.some(column => column.name === 'voto');
+
+if (!hasVoto) {
+  db.prepare('ALTER TABLE votantes ADD COLUMN voto INTEGER DEFAULT 0').run();
+  console.log('Added voto column to votantes table');
+} else {
+  console.log('voto column already exists in votantes table');
+}


### PR DESCRIPTION
## Summary
- add `voto` field with default 0 to `votantes` table creation
- provide migration script to add `voto` column for existing databases

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689147ee5c008329a2ac87839d1d4c95