### PR TITLE
feat: add voter statistics modal

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   IonPage,
   IonHeader,
@@ -7,11 +7,14 @@ import {
   IonButtons,
   IonButton,
   IonFooter,
-  IonIcon
+  IonIcon,
+  IonModal,
+  IonContent
 } from '@ionic/react';
 import { chevronBackOutline } from 'ionicons/icons';
 import { useHistory } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
+import { voterDB } from '../voterDB';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -22,6 +25,24 @@ interface LayoutProps {
 const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
   const { logout } = useAuth();
   const history = useHistory();
+  const [showStats, setShowStats] = useState(false);
+  const [totalVoters, setTotalVoters] = useState(0);
+  const [votedCount, setVotedCount] = useState(0);
+
+  useEffect(() => {
+    if (!showStats) {
+      setTotalVoters(0);
+      setVotedCount(0);
+    }
+  }, [showStats]);
+
+  const handleStats = async () => {
+    const total = await voterDB.voters.count();
+    const voted = await voterDB.voters.where('voto').equals(true).count();
+    setTotalVoters(total);
+    setVotedCount(voted);
+    setShowStats(true);
+  };
 
   return (
     <IonPage className="flex flex-col min-h-screen">
@@ -41,10 +62,21 @@ const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
           )}
           <IonTitle className="font-bold text-lg">Fiscalizacion App</IonTitle>
           <IonButtons slot="end">
+            <IonButton color="light" onClick={handleStats}>Estadísticas</IonButton>
             <IonButton color="light" onClick={logout}>Desloguearse</IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>
+      <IonModal isOpen={showStats} onDidDismiss={() => setShowStats(false)}>
+        <IonContent className="p-4">
+          <p>Cantidad de votantes: {totalVoters}</p>
+          <p>Cantidad que votó: {votedCount}</p>
+          <p>
+            Porcentaje: {totalVoters ? ((votedCount / totalVoters) * 100).toFixed(2) : '0.00'}%
+          </p>
+          <IonButton onClick={() => setShowStats(false)}>Cerrar</IonButton>
+        </IonContent>
+      </IonModal>
       {children}
       {footer && <IonFooter>{footer}</IonFooter>}
     </IonPage>


### PR DESCRIPTION
## Summary
- show voter statistics in Layout with an IonModal
- add Estadísticas button to fetch totals and voted counts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689159efbdd08329a349fab98d87f6bc