### PR TITLE
Usa campo voto en VoterList

### DIFF
--- a/src/pages/VoterList.test.tsx
+++ b/src/pages/VoterList.test.tsx
@@ -21,7 +21,7 @@ describe('VoterList', () => {
           }
         ],
         fechaEnviado: new Date().toISOString(),
-        voted: false,
+        voto: false,
       },
     ]);
   });
@@ -39,7 +39,7 @@ describe('VoterList', () => {
     await waitFor(() => expect(getAllByText(/John/).length).toBeGreaterThan(0));
   });
 
-  it('marks voter as voted when button is clicked', async () => {
+  it('marks voter as voto when button is clicked', async () => {
     const history = createMemoryHistory({ initialEntries: ['/voters'] });
     const { getByTestId, queryByText, getAllByText } = render(
       <AuthProvider>
@@ -55,7 +55,7 @@ describe('VoterList', () => {
     const toggleBtn = getByTestId('toggle-vote');
     fireEvent.click(toggleBtn);
 
-    await waitFor(() => expect(queryByText('Votó')).toBeTruthy());
+    await waitFor(() => expect(getAllByText('Votó').length).toBeGreaterThan(0));
     const row = getByTestId('voter-row-0');
     expect(row.className).toContain('bg-green-50');
   });

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -68,7 +68,7 @@ const deleteVoter = async (id: number) => {
 };
 
 
-const toggleVoted = async (id: number) => {
+const toggleVoto = async (id: number) => {
   const voterToToggle = voters.find(v => v.id === id);
   if (!voterToToggle) return;
 
@@ -212,7 +212,7 @@ const toggleVoted = async (id: number) => {
                 <button
                   data-testid="toggle-vote"
                   className="px-2 py-1 text-xs font-medium text-white bg-blue-500 rounded hover:bg-blue-600"
-                 onClick={() => toggleVoted(id)}
+                 onClick={() => toggleVoto(id)}
                 >
                   Marcar voto
                 </button>
@@ -225,7 +225,7 @@ const toggleVoted = async (id: number) => {
                 className={`w-32 px-2 py-1 text-xs font-medium text-white rounded ${
                   voto ? 'bg-green-500' : 'bg-blue-500'
                 }`}
-                onClick={() => toggleVoted(id)}
+                onClick={() => toggleVoto(id)}
               >
                 {voto ? 'Votó' : 'Votar'}
               </button>


### PR DESCRIPTION
## Summary
- Rename vote toggle handler and state updates to use `voto`
- Update VoterList tests to seed and check `voto`

## Testing
- `npm test` (fails: Missing script)
- `npm run test.unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689159f0ef2483299b1aee4084b0ab1c