### PR TITLE
Ordenar votantes por número de orden

### DIFF
--- a/server/routes/voters.js
+++ b/server/routes/voters.js
@@ -4,7 +4,9 @@ import db from '../db.js';
 const router = Router();
 
 router.get('/', (req, res) => {
-  const voters = db.prepare('SELECT * FROM votantes').all();
+  const voters = db
+    .prepare('SELECT * FROM votantes ORDER BY numero_de_orden')
+    .all();
   res.json(voters);
 });
 


### PR DESCRIPTION
## Summary
- Ordena los votantes de la API por `numero_de_orden` para una respuesta consistente

## Testing
- `npm test server/voters.test.ts` *(falla: Missing script)*
- `npx vitest run server/voters.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68915a0659f48329bd3789b17ff4029e