### PR TITLE
feat: show escrutinio modal on end voting

### DIFF
--- a/src/pages/EscrutinioModal.tsx
+++ b/src/pages/EscrutinioModal.tsx
@@ -1,0 +1,110 @@
+import {
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonItem,
+  IonLabel,
+  IonButtons
+} from '@ionic/react';
+import { useState } from 'react';
+import { Button, Input } from '../components';
+
+interface EscrutinioModalProps {
+  onClose: () => void;
+}
+
+interface ResultadoEscrutinio {
+  lista100: number;
+  votoEnBlanco: number;
+  nulo: number;
+  recurrido: number;
+}
+
+const EscrutinioModal: React.FC<EscrutinioModalProps> = ({ onClose }) => {
+  const [lista100, setLista100] = useState('');
+  const [votoEnBlanco, setVotoEnBlanco] = useState('');
+  const [nulo, setNulo] = useState('');
+  const [recurrido, setRecurrido] = useState('');
+
+  const handleSubmit = async () => {
+    const datos: ResultadoEscrutinio = {
+      lista100: parseInt(lista100, 10) || 0,
+      votoEnBlanco: parseInt(votoEnBlanco, 10) || 0,
+      nulo: parseInt(nulo, 10) || 0,
+      recurrido: parseInt(recurrido, 10) || 0
+    };
+    const mesaId = Number(localStorage.getItem('mesaId'));
+    try {
+      const res = await fetch('/api/escrutinio', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mesa_id: mesaId,
+          datos: JSON.stringify(datos)
+        })
+      });
+      if (res.ok) {
+        alert('Escrutinio enviado correctamente');
+        onClose();
+      } else {
+        alert(res.statusText || 'Error al enviar escrutinio');
+      }
+    } catch {
+      alert('Error al enviar escrutinio');
+    }
+  };
+
+  return (
+    <>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>Escrutinio</IonTitle>
+          <IonButtons slot="end">
+            <Button onClick={onClose}>Cancelar</Button>
+          </IonButtons>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <IonItem>
+          <IonLabel position="stacked">Lista 100</IonLabel>
+          <Input
+            type="number"
+            value={lista100}
+            onIonChange={e => setLista100(e.detail.value ?? '')}
+          />
+        </IonItem>
+        <IonItem>
+          <IonLabel position="stacked">Voto en blanco</IonLabel>
+          <Input
+            type="number"
+            value={votoEnBlanco}
+            onIonChange={e => setVotoEnBlanco(e.detail.value ?? '')}
+          />
+        </IonItem>
+        <IonItem>
+          <IonLabel position="stacked">Nulo</IonLabel>
+          <Input
+            type="number"
+            value={nulo}
+            onIonChange={e => setNulo(e.detail.value ?? '')}
+          />
+        </IonItem>
+        <IonItem>
+          <IonLabel position="stacked">Recurrido</IonLabel>
+          <Input
+            type="number"
+            value={recurrido}
+            onIonChange={e => setRecurrido(e.detail.value ?? '')}
+          />
+        </IonItem>
+        <Button expand="block" className="ion-margin-top" onClick={handleSubmit}>
+          Enviar
+        </Button>
+      </IonContent>
+    </>
+  );
+};
+
+export default EscrutinioModal;
+

--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -4,6 +4,7 @@ import {
   IonTitle,
   IonContent,
   IonButtons,
+  IonModal,
   IonFooter,
   IonIcon,
   IonItem,
@@ -18,6 +19,7 @@ import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { voterDB } from '../voterDB';
 import { useAuth } from '../AuthContext';
+import EscrutinioModal from './EscrutinioModal';
 
 interface Voter {
   id?: number;
@@ -44,6 +46,7 @@ const VoterList: React.FC = () => {
   const [voters, setVoters] = useState<Voter[]>([]);
   const [searchDni, setSearchDni] = useState('');
   const [searchOrden, setSearchOrden] = useState('');
+  const [showEscrutinioModal, setShowEscrutinioModal] = useState(false);
   const history = useHistory();
 
   const loadVoters = async () => {
@@ -96,7 +99,7 @@ const toggleVoto = async (id: number) => {
     } catch (err) {
       console.error('Error taking photo', err);
     }
-    history.push('/escrutinio');
+    setShowEscrutinioModal(true);
   };
 
   const handleConfig = () => {
@@ -254,6 +257,13 @@ const toggleVoto = async (id: number) => {
     )}
   </div>
 </IonContent>
+
+      <IonModal
+        isOpen={showEscrutinioModal}
+        onDidDismiss={() => setShowEscrutinioModal(false)}
+      >
+        <EscrutinioModal onClose={() => setShowEscrutinioModal(false)} />
+      </IonModal>
 
       <IonFooter>
         <IonToolbar>


### PR DESCRIPTION
## Summary
- open escrutinio modal from voter list instead of navigation
- add escrutinio modal component for submitting results

## Testing
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_689178b80e708329a50cb3d797d787bb