### PR TITLE
fix: remove stray lines from users route

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,6 +1,3 @@
-+5
--3
-
 import { Router } from 'express';
 import bcrypt from 'bcryptjs';
 import { usersCollection } from '../firebase/index.js';


### PR DESCRIPTION
## Summary
- remove leftover "+5" and "-3" markers from users route
- ensure router import is the first line

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test.unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899455166108329a1abefa459a85f03