### PR TITLE
Configure mongoose for VotanteEstablecimiento model

### DIFF
--- a/server/models/VotanteEstablecimiento.js
+++ b/server/models/VotanteEstablecimiento.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import '../mongoose.js';
 
 const personaSchema = new mongoose.Schema({
   dni: String,

--- a/server/mongoose.js
+++ b/server/mongoose.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/fiscalizacion';
+
+mongoose.connect(MONGO_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+export default mongoose;
+


### PR DESCRIPTION
## Summary
- Import mongoose connection utility in VotanteEstablecimiento model and export the model with mongoose.model
- Add basic mongoose connection helper

## Testing
- `npm run lint`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_68994555a054832988af0185f041228b