### PR TITLE
Check user existence before password validation

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -44,6 +44,9 @@ router.post('/login', async (req, res) => {
       return res.status(401).json({ error: 'Invalid credentials' });
     }
     const user = doc.data();
+    if (!user || !user.passwordHash) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
     const valid = await bcrypt.compare(password, user.passwordHash);
     if (!valid) {
       return res.status(401).json({ error: 'Invalid credentials' });


### PR DESCRIPTION
## Summary
- Verify retrieved user and password hash exist before comparing credentials

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test.unit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aba86861b083298ee0e1a5c5d7e512