### PR TITLE
Use voter id as map key in VoterList

### DIFF
--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -210,7 +210,7 @@ const toggleVoto = async (id: number) => {
 
         return (
           <div
-            key={index}
+            key={voter.id}
             data-testid={`voter-row-${index}`}
             className={`rounded shadow p-4 grid grid-cols-5 items-center gap-2 ${
               voter.voto ? 'bg-green-50' : 'bg-white'


### PR DESCRIPTION
## Summary
- use voter id instead of array index as key when rendering filtered voters

## Testing
- `npm run test.unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aba868ff7c83298897c61d8731cbdc