### PR TITLE
Use API-based login instead of Firebase auth

### DIFF
--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -28,37 +28,19 @@ const renderWithAuth = (authValue: Partial<AuthContextType> = {}) => {
 };
 
 describe('Login', () => {
-  test('calls login with email and password', async () => {
+  test('calls login with usuario and password', async () => {
     const { container, auth } = renderWithAuth();
-    const emailInput = container.querySelector('ion-input[type="email"]');
-    const passwordInput = container.querySelector('ion-input[type="password"]');
-    const form = container.querySelector('form');
-
-    fireEvent(emailInput!, new CustomEvent('ionChange', { detail: { value: 'test@example.com' } }));
-    fireEvent(passwordInput!, new CustomEvent('ionChange', { detail: { value: 'pass' } }));
-    fireEvent.submit(form!);
-
-    await waitFor(() => {
-      expect(auth.login).toHaveBeenCalledWith('test@example.com', 'pass');
-    });
-  });
-
-  test('calls loginWithDni with dni and password', async () => {
-    const { container, auth } = renderWithAuth();
-    const segment = container.querySelector('ion-segment');
-    fireEvent(segment!, new CustomEvent('ionChange', { detail: { value: 'dni' } }));
-
     const inputs = container.querySelectorAll('ion-input');
-    const dniInput = inputs[0];
+    const usuarioInput = inputs[0];
     const passwordInput = inputs[1];
     const form = container.querySelector('form');
 
-    fireEvent(dniInput!, new CustomEvent('ionChange', { detail: { value: '12345678' } }));
+    fireEvent(usuarioInput!, new CustomEvent('ionChange', { detail: { value: 'testuser' } }));
     fireEvent(passwordInput!, new CustomEvent('ionChange', { detail: { value: 'pass' } }));
     fireEvent.submit(form!);
 
     await waitFor(() => {
-      expect(auth.loginWithDni).toHaveBeenCalledWith('12345678', 'pass');
+      expect(auth.login).toHaveBeenCalledWith('testuser', 'pass');
     });
   });
 });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -5,9 +5,7 @@ import {
   IonContent,
   IonItem,
   IonLabel,
-  IonList,
-  IonSegment,
-  IonSegmentButton
+  IonList
 } from '@ionic/react';
 import { Button, Input } from '../components';
 import { useState } from 'react';
@@ -17,37 +15,18 @@ import Layout from '../components/Layout';
 
 const Login: React.FC = () => {
   const history = useHistory();
-  const { login, loginWithDni } = useAuth();
-  const [mode, setMode] = useState<'email' | 'dni'>('email');
-  const [email, setEmail] = useState('');
-  const [dni, setDni] = useState('');
-  const [emailPassword, setEmailPassword] = useState('');
-  const [dniPassword, setDniPassword] = useState('');
+  const { login } = useAuth();
+  const [usuario, setUsuario] = useState('');
+  const [password, setPassword] = useState('');
 
-  const handleEmailLogin = async (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await login(email, emailPassword);
+      await login(usuario, password);
       history.push('/select-mesa');
     } catch (err) {
       console.error(err);
-
-      alert('Usuario o clave incorrectos'); // Show error message if login fails.
-    }
-  };
-
-  const handleDniLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    try {
-
-      console.log(dni, dniPassword); // Log DNI and password values.
-      await loginWithDni(dni, dniPassword);
-
-      history.push('/select-mesa'); // Navigate to select-mesa page after successful login.
-    } catch (err) {
-      console.error(err);
-
-      alert('Usuario o clave incorrectos'); // Show error message if login fails.
+      alert('Usuario o clave incorrectos');
     }
   };
 
@@ -59,66 +38,30 @@ const Login: React.FC = () => {
         </IonToolbar>
       </IonHeader>
       <IonContent className="ion-padding">
-        <IonSegment value={mode} onIonChange={(e) => setMode(e.detail.value as 'email' | 'dni')}>
-          <IonSegmentButton value="email">
-            <IonLabel>Email</IonLabel>
-          </IonSegmentButton>
-          <IonSegmentButton value="dni">
-            <IonLabel>DNI</IonLabel>
-          </IonSegmentButton>
-        </IonSegment>
-        {mode === 'email' ? (
-          <form onSubmit={handleEmailLogin}>
-            <IonList>
-              <IonItem>
-                <IonLabel position="floating">Email</IonLabel>
-                <Input
-                  type="email"
-                  value={email}
-                  onIonChange={(e) => setEmail(e.detail.value!)}
-                  required
-                />
-              </IonItem>
-              <IonItem>
-                <IonLabel position="floating">Clave</IonLabel>
-                <Input
-                  type="password"
-                  value={emailPassword}
-                  onIonChange={(e) => setEmailPassword(e.detail.value!)}
-                  required
-                />
-              </IonItem>
-            </IonList>
-            <Button expand="block" type="submit" className="ion-margin-top">
-              INGRESAR
-            </Button>
-          </form>
-        ) : (
-          <form onSubmit={handleDniLogin}>
-            <IonList>
-              <IonItem>
-                <IonLabel position="floating">DNI</IonLabel>
-                <Input
-                  value={dni}
-                  onIonChange={(e) => setDni(e.detail.value!)}
-                  required
-                />
-              </IonItem>
-              <IonItem>
-                <IonLabel position="floating">Clave</IonLabel>
-                <Input
-                  type="password"
-                  value={dniPassword}
-                  onIonChange={(e) => setDniPassword(e.detail.value!)}
-                  required
-                />
-              </IonItem>
-            </IonList>
-            <Button expand="block" type="submit" className="ion-margin-top">
-              INGRESAR
-            </Button>
-          </form>
-        )}
+        <form onSubmit={handleLogin}>
+          <IonList>
+            <IonItem>
+              <IonLabel position="floating">Usuario</IonLabel>
+              <Input
+                value={usuario}
+                onIonChange={(e) => setUsuario(e.detail.value!)}
+                required
+              />
+            </IonItem>
+            <IonItem>
+              <IonLabel position="floating">Clave</IonLabel>
+              <Input
+                type="password"
+                value={password}
+                onIonChange={(e) => setPassword(e.detail.value!)}
+                required
+              />
+            </IonItem>
+          </IonList>
+          <Button expand="block" type="submit" className="ion-margin-top">
+            INGRESAR
+          </Button>
+        </form>
         {/**
          * Button to navigate to register page.
          */}


### PR DESCRIPTION
## Summary
- Replace Firebase email/password login with API POST request and session handling
- Simplify login form to send `usuario` and password
- Update login tests for new authentication flow

## Testing
- `npm run lint`
- `npm run test.unit` (fails: Cannot read properties of undefined (reading 'getProvider'))

------
https://chatgpt.com/codex/tasks/task_e_68abb7ff5364832991ff4476e3d6d5ac