### PR TITLE
feat: add login route logging

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ import voterRoutes from './routes/voters.js';
 import mesaRoutes from './routes/mesas.js';
 import userRoutes from './routes/users.js';
 import escrutinioRoutes from './routes/escrutinio.js';
+import logger from './logger.js';
 
 const app = express();
 
@@ -54,7 +55,7 @@ app.use('/api/escrutinio', escrutinioRoutes);
 if (process.env.NODE_ENV !== 'test') {
   const PORT = process.env.PORT || 3000;
   app.listen(PORT, () => {
-    console.log(`Server running on port ${PORT}`);
+    logger.info(`Server running on port ${PORT}`);
   });
 }
 

--- a/server/logger.js
+++ b/server/logger.js
@@ -1,0 +1,13 @@
+import winston from 'winston';
+
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json()
+  ),
+  transports: [new winston.transports.Console()]
+});
+
+export default logger;
+

--- a/server/migrations/add-voto-column.js
+++ b/server/migrations/add-voto-column.js
@@ -1,11 +1,12 @@
 import db from '../db.js';
+import logger from '../logger.js';
 
 const columns = db.prepare("PRAGMA table_info(votantes)").all();
 const hasVoto = columns.some(column => column.name === 'voto');
 
 if (!hasVoto) {
   db.prepare('ALTER TABLE votantes ADD COLUMN voto INTEGER DEFAULT 0').run();
-  console.log('Added voto column to votantes table');
+  logger.info('Added voto column to votantes table');
 } else {
-  console.log('voto column already exists in votantes table');
+  logger.info('voto column already exists in votantes table');
 }

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "better-sqlite3": "^9.0.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "firebase-admin": "^11.10.0"
+    "firebase-admin": "^11.10.0",
+    "winston": "^3.17.0"
   }
 }

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import bcrypt from 'bcryptjs';
 import { usersCollection } from '../firebase/index.js';
+import logger from '../logger.js';
 
 const router = Router();
 
@@ -35,24 +36,33 @@ router.post('/', async (req, res) => {
 // Login route. Verify the dni exists and the password matches the stored hash.
 router.post('/login', async (req, res) => {
   const { dni, password } = req.body;
+  const timestamp = new Date().toISOString();
+  logger.info('Login attempt', { dni, timestamp });
+
   if (!dni || !password) {
+    logger.warn('Missing credentials', { dni, timestamp });
     return res.status(400).json({ error: 'Missing credentials' });
   }
   try {
     const doc = await usersCollection.doc(dni).get();
     if (!doc.exists) {
+      logger.warn('User not found', { dni, timestamp });
       return res.status(401).json({ error: 'Invalid credentials' });
     }
     const user = doc.data();
     if (!user || !user.passwordHash) {
+      logger.warn('User data invalid', { dni, timestamp });
       return res.status(401).json({ error: 'Invalid credentials' });
     }
     const valid = await bcrypt.compare(password, user.passwordHash);
     if (!valid) {
+      logger.warn('Password mismatch', { dni, timestamp });
       return res.status(401).json({ error: 'Invalid credentials' });
     }
+    logger.info('Login successful', { dni, timestamp });
     res.json({ email: user.email, dni, uid: user.uid });
   } catch (err) {
+    logger.error('Login failed', { dni, timestamp, error: err.message });
     res.status(500).json({ error: 'Login failed' });
   }
 });


### PR DESCRIPTION
## Summary
- add winston logger configuration
- log login attempts and outcomes
- use logger instead of console in server modules

## Testing
- `npm run test.unit` *(fails: TypeError: Cannot read properties of undefined (reading 'getProvider'))*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68acde1508248329a16adfa6be13ce1b