### PR TITLE
Redirect login to fiscalización lookup

### DIFF
--- a/cypress/e2e/flow.cy.ts
+++ b/cypress/e2e/flow.cy.ts
@@ -17,7 +17,7 @@ describe('Authentication Flow', () => {
     cy.get('ion-input[type="email"]').type('test@example.com');
     cy.get('ion-input[type="password"]').type('pass');
     cy.contains('button', 'INGRESAR').click();
-    cy.url().should('include', '/select-mesa');
+    cy.url().should('include', '/fiscalizacion-lookup');
   });
 
   it('logs in with DNI', () => {
@@ -26,6 +26,6 @@ describe('Authentication Flow', () => {
     cy.get('ion-input').first().type('12345678');
     cy.get('ion-input[type="password"]').type('pass');
     cy.contains('button', 'INGRESAR').click();
-    cy.url().should('include', '/select-mesa');
+    cy.url().should('include', '/fiscalizacion-lookup');
   });
 });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -23,7 +23,7 @@ const Login: React.FC = () => {
     e.preventDefault();
     try {
       await login(usuario, password);
-      history.push('/select-mesa');
+      history.push('/fiscalizacion-lookup');
     } catch (err) {
       console.error(err);
       alert('Usuario o clave incorrectos');


### PR DESCRIPTION
## Summary
- Redirect login submissions to `/fiscalizacion-lookup`
- Update Cypress flow tests for new login destination

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test.unit` *(fails: Failed to resolve import "@capacitor-firebase/authentication")*
- `npm run lint` *(fails: 2 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b0811ff61483298de2b0e24623feb2