### PR TITLE
feat: update login request to use dni endpoint

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -54,12 +54,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const login = async (usuario: string, password: string): Promise<string> => {
     try {
-      const baseUrl =
-        process.env.API_URL ?? 'http://api.lalibertadavanzacomuna7.com/api';
-      const response = await fetch(`${baseUrl}/auth/login`, {
+      const response = await fetch('/api/users/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ usuario, password }),
+        body: JSON.stringify({ dni: usuario, password }),
       });
 
       if (!response.ok) {
@@ -79,8 +77,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       const info: UserInfo = {
         uid: data.uid ?? '',
-        email: data.email ?? usuario,
-        dni: data.dni,
+        email: data.email ?? null,
+        dni: data.dni ?? usuario,
       };
 
       setUser(info);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,14 +16,16 @@ import Layout from '../components/Layout';
 const Login: React.FC = () => {
   const history = useHistory();
   const { login, loginWithGoogle } = useAuth();
-  const [usuario, setUsuario] = useState('');
+  const [dni, setDni] = useState('');
   const [password, setPassword] = useState('');
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await login(usuario, password);
-      history.push('/fiscalizacion-lookup');
+      const token = await login(dni, password);
+      if (token) {
+        history.push('/fiscalizacion-lookup');
+      }
     } catch (err) {
       console.error(err);
       alert('Usuario o clave incorrectos');
@@ -51,10 +53,10 @@ const Login: React.FC = () => {
         <form onSubmit={handleLogin}>
           <IonList>
             <IonItem>
-              <IonLabel position="floating">Usuario</IonLabel>
+              <IonLabel position="floating">DNI</IonLabel>
               <Input
-                value={usuario}
-                onIonChange={(e) => setUsuario(e.detail.value!)}
+                value={dni}
+                onIonChange={(e) => setDni(e.detail.value!)}
                 required
               />
             </IonItem>


### PR DESCRIPTION
## Summary
- use `/api/users/login` endpoint with DNI credentials
- update login page to capture DNI and wait for token before redirecting

## Testing
- `npm run lint`
- `npm run test.unit` *(fails: Failed to resolve import "@capacitor-firebase/authentication" from "src/AuthContext.tsx")*

------
https://chatgpt.com/codex/tasks/task_e_68b0876ca4288329b936a0263654da6e