### PR TITLE
fix: adjust back link for fiscalizacion lookup page

### DIFF
--- a/src/pages/FiscalizacionLookup.tsx
+++ b/src/pages/FiscalizacionLookup.tsx
@@ -46,7 +46,7 @@ const FiscalizacionLookup: React.FC = () => {
   };
 
   return (
-    <Layout backHref="/select-mesa">
+    <Layout backHref="/login">
       <IonContent className="ion-padding">
         <form onSubmit={handleSubmit}>
           <IonItem>


### PR DESCRIPTION
## Summary
- direct FiscalizacionLookup back button to `/login`

## Testing
- `npm run lint`
- `npm run test.unit` *(fails: Cannot read properties of undefined (reading 'getProvider'))*

------
https://chatgpt.com/codex/tasks/task_e_68b08cb8b90883298559b9b173c23013