### PR TITLE
Fix input maxLength props on mesa selection

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { IonInput } from '@ionic/react';
 
-export type InputProps = React.ComponentProps<typeof IonInput>;
+export type InputProps = Omit<React.ComponentProps<typeof IonInput>, 'maxlength'> & {
+  maxLength?: number;
+};
 
-const Input: React.FC<InputProps> = ({ className = '', ...rest }) => {
+const Input: React.FC<InputProps> = ({ className = '', maxLength, ...rest }) => {
   return (
     <IonInput
       className={`border border-gray-300 rounded px-2 py-1 ${className}`}
+      maxlength={maxLength}
       {...rest}
     />
   );

--- a/src/pages/SelectMesa.tsx
+++ b/src/pages/SelectMesa.tsx
@@ -89,7 +89,7 @@ const SelectMesa: React.FC = () => {
           <Input
             value={seccion}
             inputmode="numeric"
-            maxlength={3}
+            maxLength={3}
             disabled={!editing}
             onIonChange={(e) => setSeccion(e.detail.value ?? '')}
           />
@@ -99,7 +99,7 @@ const SelectMesa: React.FC = () => {
           <Input
             value={circuito}
             inputmode="numeric"
-            maxlength={3}
+            maxLength={3}
             disabled={!editing}
             onIonChange={(e) => setCircuito(e.detail.value ?? '')}
           />
@@ -109,7 +109,7 @@ const SelectMesa: React.FC = () => {
           <Input
             value={mesa}
             inputmode="numeric"
-            maxlength={4}
+            maxLength={4}
             disabled={!editing}
             onIonChange={(e) => setMesa(e.detail.value ?? '')}
           />


### PR DESCRIPTION
## Summary
- use `maxLength` prop in SelectMesa inputs
- accept `maxLength` and map to `maxlength` in Input component

## Testing
- `npm run build` *(fails: AuthContext.tsx unused '@ts-expect-error' directive; FiscalizacionLookup.tsx unknown type; Login.test.tsx missing properties)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e883e8448329a426ac018e238903