### PR TITLE
fix: send raw datos in EscrutinioModal fetch

### DIFF
--- a/src/pages/EscrutinioModal.tsx
+++ b/src/pages/EscrutinioModal.tsx
@@ -41,7 +41,7 @@ const EscrutinioModal: React.FC<EscrutinioModalProps> = ({ onClose }) => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           mesa_id: mesaId,
-          datos: JSON.stringify(datos)
+          datos
         })
       });
       if (res.ok) {


### PR DESCRIPTION
## Summary
- send `datos` object directly instead of double JSON stringifying in `EscrutinioModal`

## Testing
- `npm run lint`
- `npm run test.unit` *(fails: Cannot read properties of undefined (reading 'getProvider'))*

------
https://chatgpt.com/codex/tasks/task_e_68b0e887cf6083298e75412fcb94a6e0