### PR TITLE
feat: add fiscalization actions page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Escrutinio from './pages/Escrutinio';
 import VoterCount from './pages/VoterCount';
 import SelectMesa from './pages/SelectMesa';
 import FiscalizacionLookup from './pages/FiscalizacionLookup';
+import FiscalizacionActions from './pages/FiscalizacionActions';
 import { AuthProvider } from './AuthContext';
 import PrivateRoute from './PrivateRoute';
 
@@ -78,6 +79,11 @@ const App: React.FC = () => (
             exact
             path="/fiscalizacion-lookup"
             component={FiscalizacionLookup}
+          />
+          <PrivateRoute
+            exact
+            path="/fiscalizacion-acciones"
+            component={FiscalizacionActions}
           />
           <Route exact path="/escrutinio">
             <Escrutinio />

--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -1,0 +1,16 @@
+import { IonContent } from '@ionic/react';
+import Layout from '../components/Layout';
+import { Button } from '../components';
+
+const FiscalizacionActions: React.FC = () => {
+  return (
+    <Layout backHref="/fiscalizacion-lookup">
+      <IonContent className="ion-padding flex flex-col gap-4">
+        <Button routerLink="/voters">Votación</Button>
+        <Button routerLink="/escrutinio">Enviar Resultado</Button>
+      </IonContent>
+    </Layout>
+  );
+};
+
+export default FiscalizacionActions;

--- a/src/pages/FiscalizacionLookup.tsx
+++ b/src/pages/FiscalizacionLookup.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { IonContent, IonItem, IonLabel } from '@ionic/react';
+import { useHistory } from 'react-router-dom';
 import Layout from '../components/Layout';
 import { Button, Input } from '../components';
 
@@ -57,6 +58,7 @@ const FiscalizacionLookup: React.FC = () => {
   const [dni, setDni] = useState('');
   const [result, setResult] = useState<unknown | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const history = useHistory();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -95,6 +97,8 @@ const FiscalizacionLookup: React.FC = () => {
       }
 
       setResult(r.payload);
+      localStorage.setItem('fiscalData', JSON.stringify(r.payload));
+      history.push('/fiscalizacion-acciones', { fiscalData: r.payload });
 
       // (Opcional) ejemplo de “listar” con asignado: true
       // const l = await postJson(


### PR DESCRIPTION
## Summary
- add fiscalization actions page with voting and result buttons
- protect new page with a PrivateRoute
- redirect lookup success to actions page and store data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test.unit` *(fails: Cannot read properties of undefined (reading 'getProvider'))*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b10129b16c8329a73748f5537148d3