### PR TITLE
Show DNI not registered message

### DIFF
--- a/src/pages/FiscalizacionLookup.tsx
+++ b/src/pages/FiscalizacionLookup.tsx
@@ -90,7 +90,7 @@ const FiscalizacionLookup: React.FC = () => {
           typeof r.payload === 'string'
             ? r.payload
             : r.payload?.message || 'Error en la solicitud';
-        setError(msg);
+        setError(msg === 'Error en la solicitud' ? 'DNI no registrado' : msg);
         return;
       }
 
@@ -105,7 +105,8 @@ const FiscalizacionLookup: React.FC = () => {
       // if (!l.ok) throw new Error(typeof l.payload === 'string' ? l.payload : (l.payload as { message?: string }).message || 'Error en listar');
       // setResult(l.payload);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error en la solicitud');
+      const msg = err instanceof Error ? err.message : 'Error en la solicitud';
+      setError(msg === 'Error en la solicitud' ? 'DNI no registrado' : msg);
     }
   };
 


### PR DESCRIPTION
## Summary
- Display a specific "DNI no registrado" error when the API returns or throws a generic "Error en la solicitud"

## Testing
- `npm run test.unit` *(fails: TypeError Cannot read properties of undefined (reading 'getProvider'))*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b10129b1b483299b121395f2a1398a