### PR TITLE
feat: persist fiscal data

### DIFF
--- a/src/FiscalDataContext.tsx
+++ b/src/FiscalDataContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 
 interface FiscalDataContextValue {
   fiscalData: unknown | null;
@@ -17,6 +17,14 @@ export const FiscalDataProvider: React.FC<{ children: React.ReactNode }> = ({
     const stored = localStorage.getItem('fiscalData');
     return stored ? JSON.parse(stored) : null;
   });
+
+  useEffect(() => {
+    if (fiscalData === null) {
+      localStorage.removeItem('fiscalData');
+    } else {
+      localStorage.setItem('fiscalData', JSON.stringify(fiscalData));
+    }
+  }, [fiscalData]);
 
   const value: FiscalDataContextValue = {
     fiscalData,


### PR DESCRIPTION
## Summary
- persist fiscal data in localStorage

## Testing
- `npm run test.unit` *(fails: better-sqlite3 compiled against different Node.js version; Firebase storage provider undefined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b35cf0d0f483299f724ee651773f6e