### PR TITLE
Include photo in escrutinio submissions

### DIFF
--- a/server/routes/escrutinio.js
+++ b/server/routes/escrutinio.js
@@ -12,7 +12,7 @@ router.post('/', (req, res) => {
   const { mesa_id, datos, foto } = req.body;
   const info = db
     .prepare('INSERT INTO escrutinio (mesa_id, datos, foto) VALUES (?, ?, ?)')
-    .run(mesa_id, datos, foto);
+    .run(mesa_id, datos, foto ?? null);
   res.status(201).json({ id: info.lastInsertRowid });
 });
 

--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -103,11 +103,13 @@ const Escrutinio: React.FC = () => {
     mesa_id: mesaId,
     datos,
     fecha: new Date().toISOString(),
+    foto,
     // podés sumar más campos si querés
   };
   try {
     await addDoc(collection(db, 'escrutinio'), payload);
     alert('Escrutinio enviado correctamente');
+    setFoto('');
   } catch (err) {
     alert('Error al guardar en Firestore');
     console.error(err);


### PR DESCRIPTION
## Summary
- add `foto` field to escrutinio payload and clear it after successful send
- ensure backend route stores `foto` value (defaulting to null when missing)

## Testing
- `npm run lint`
- `npm run test.unit` (fails: TypeError: Cannot read properties of undefined (reading 'getProvider'))

------
https://chatgpt.com/codex/tasks/task_e_68b35cf4dee88329b22e5149ef800cb2