### PR TITLE
feat: persist API token for DNI login and registration

### DIFF
--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -13,7 +13,7 @@ const renderWithAuth = (authValue: Partial<AuthContextType> = {}) => {
     login: vi.fn().mockResolvedValue(undefined),
     loginWithDni: vi.fn().mockResolvedValue(undefined),
     loginWithGoogle: vi.fn().mockResolvedValue(undefined),
-    register: vi.fn(),
+    register: vi.fn().mockResolvedValue(undefined),
     logout: vi.fn(),
     isAuthenticated: false,
   };


### PR DESCRIPTION
## Summary
- capture and persist API token during DNI-based login if provided
- attempt to retrieve and store token after user registration, logging absence
- clarify AuthContext types for token-aware flows and adjust tests

## Testing
- `npm run lint`
- `npm run test.unit` *(fails: Cannot read properties of undefined (reading 'getProvider'))*

------
https://chatgpt.com/codex/tasks/task_e_68b35cf6639483299a9c73d8a1a4d45d