### PR TITLE
Include special vote fields in escrutinio payload

### DIFF
--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -95,7 +95,11 @@ const Escrutinio: React.FC = () => {
   listas.forEach(l => {
     datos[l.lista] = parseInt(valores[l.id], 10) || 0;
   });
-  
+
+  CAMPOS_ESPECIALES.forEach(key => {
+    datos[key] = parseInt(valores[key], 10) || 0;
+  });
+
   setResultado(datos);
 
   const mesaId = Number(localStorage.getItem('mesaId'));


### PR DESCRIPTION
## Summary
- capture special vote fields (blanco, recurridos, nulos, impugnados) during escrutinio submission
- ensure payload stores all vote categories before saving to Firestore

## Testing
- `npm run lint`
- `npm run test.unit` *(fails: ReferenceError: beforeEach is not defined; Firebase auth invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68be340063ec8329bbc158ea13500879