### PR TITLE
feat: add logout handler to Layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -45,6 +45,11 @@ const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
     setShowStats(true);
   };
 
+  const handleLogout = async () => {
+    await logout();
+    history.push('/login');
+  };
+
   return (
     <IonPage className="flex flex-col min-h-screen">
       <IonHeader className="bg-primary-500 text-white">
@@ -64,7 +69,7 @@ const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
           <IonTitle className="font-bold text-lg">Fiscalizacion App</IonTitle>
           <IonButtons slot="end">
             <IonButton color="primary" onClick={handleStats}>Estadísticas</IonButton>
-            <IonButton color="primary" onClick={logout}>Desloguearse</IonButton>
+            <IonButton color="primary" onClick={handleLogout}>Desloguearse</IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>


### PR DESCRIPTION
## Summary
- add handleLogout that signs out and redirects to login
- wire Desloguearse button to handleLogout

## Testing
- `npm run test.unit` *(fails: beforeEach is not defined; Firebase auth invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_68be3401448c8329a4e9a53d815e5250