### PR TITLE
refactor: consolidate firestore imports in Escrutinio

### DIFF
--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -8,9 +8,8 @@ import {
 import { Button, Input } from '../components';
 import Layout from '../components/Layout';
 import { Camera, CameraResultType } from '@capacitor/camera';
-import { getDocs, collection } from 'firebase/firestore';
+import { getDocs, collection, addDoc } from 'firebase/firestore';
 import { db } from '../firebase';
-import { addDoc } from 'firebase/firestore';
 import { useHistory } from 'react-router-dom';
 import { useFiscalData } from '../FiscalDataContext';
 


### PR DESCRIPTION
## Summary
- consolidate Firestore imports into a single statement in `Escrutinio`

## Testing
- `npm run test.unit` (fails: auth/invalid-api-key, beforeEach undefined)
- `npm run test.e2e` (fails: missing Xvfb)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be3402fd348329b36ea58f3948a5b8