### PR TITLE
Add dedicated auth login route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ import voterRoutes from './routes/voters.js';
 import mesaRoutes from './routes/mesas.js';
 import userRoutes from './routes/users.js';
 import escrutinioRoutes from './routes/escrutinio.js';
+import authRoutes from './routes/auth.js';
 import logger from './logger.js';
 
 const app = express();
@@ -47,7 +48,8 @@ app.get('/health', (_req, res) => res.status(200).send('OK'));
 // === RUTAS ===
 app.use('/api/voters', voterRoutes);
 app.use('/api/mesas', mesaRoutes);
-app.use('/api/users', userRoutes);           // aquí debería estar /api/auth/login si lo manejás en users
+app.use('/api/auth', authRoutes);            // login
+app.use('/api/users', userRoutes);           // user management
 app.use('/api/escrutinio', escrutinioRoutes);
 
 // IMPORTANTE: no redirijas OPTIONS ni /api/auth/login en ningún middleware

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { loginHandler } from './users.js';
+
+const router = Router();
+
+// Dedicated auth routes
+router.post('/login', loginHandler);
+
+export default router;

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -55,8 +55,8 @@ router.post('/', async (req, res) => {
   }
 });
 
-// Login route. Verify the dni exists and the password matches the stored hash.
-router.post('/login', async (req, res) => {
+// Login route handler. Verify the dni exists and the password matches the stored hash.
+export async function loginHandler(req, res) {
   const { dni, password } = req.body;
   const timestamp = new Date().toISOString();
   logger.info('Login attempt', { dni, timestamp });
@@ -99,6 +99,8 @@ router.post('/login', async (req, res) => {
     logger.error('Login failed', { dni, timestamp, error: err.message });
     res.status(500).json({ error: 'Login failed' });
   }
-});
+}
+
+router.post('/login', loginHandler);
 
 export default router;

--- a/server/users.test.ts
+++ b/server/users.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import request from 'supertest';
-import { vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 process.env.JWT_SECRET = 'testsecret';
 
@@ -44,7 +44,7 @@ describe('Users API auth', () => {
     const newUser = { email: 'test@example.com', dni: '123', password: 'pass' };
     await request(app).post('/api/users').send(newUser);
     const loginRes = await request(app)
-      .post('/api/users/login')
+      .post('/api/auth/login')
       .send({ dni: '123', password: 'pass' });
     const token = loginRes.body.token;
 

--- a/server/voters.test.ts
+++ b/server/voters.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { beforeEach, describe, expect, it } from 'vitest';
 import request from 'supertest';
 import app from './index.js';
 import db from './db.js';

--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -67,7 +67,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const login = async (usuario: string, password: string): Promise<string> => {
     try {
-      const response = await fetch('/api/users/login', {
+      const response = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ dni: usuario, password }),
@@ -144,7 +144,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       // Intentar obtener un token desde la API
       try {
-        const response = await fetch('/api/users/login', {
+        const response = await fetch('/api/auth/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ dni, password }),
@@ -200,7 +200,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
       // Intentar recuperar token después del registro
       try {
-        const response = await fetch('/api/users/login', {
+        const response = await fetch('/api/auth/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ dni, password }),


### PR DESCRIPTION
## Summary
- add `/api/auth/login` router and mount in server
- reuse login handler from users routes and update client AuthContext
- adjust tests to target new auth endpoint

## Testing
- `npm run lint`
- `npm run test.unit` *(fails: FirebaseError auth/invalid-api-key)*
- `npx vitest run server/users.test.ts server/voters.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68be465d9e6c83299a5763b27f4883eb