### PR TITLE
fix: use actions menu route for voter list back link

### DIFF
--- a/src/pages/VoterList.tsx
+++ b/src/pages/VoterList.tsx
@@ -164,7 +164,7 @@ const toggleVoto = async (id: number) => {
   });
 
   return (
-    <Layout backHref="/select-mesa">
+    <Layout backHref="/fiscalizacion-acciones">
       <IonHeader>
         <IonToolbar>
           <IonButtons slot="start">


### PR DESCRIPTION
## Summary
- route VoterList back button to fiscalizacion actions menu

## Testing
- `npm run lint`
- `npm run test.unit` (fails: FirebaseError auth/invalid-api-key)


------
https://chatgpt.com/codex/tasks/task_e_68c21ea5fa5c832991598dc5ec532e07