### PR TITLE
Add navigation to Escrutinio from fiscalization actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import VoterCount from './pages/VoterCount';
 import SelectMesa from './pages/SelectMesa';
 import FiscalizacionLookup from './pages/FiscalizacionLookup';
 import FiscalizacionActions from './pages/FiscalizacionActions';
+import Escrutinio from './pages/Escrutinio';
 import { AuthProvider } from './AuthContext';
 import PrivateRoute from './PrivateRoute';
 import FiscalRoute from './FiscalRoute';
@@ -87,6 +88,7 @@ const App: React.FC = () => (
             path="/fiscalizacion-acciones"
             component={FiscalizacionActions}
           />
+          <FiscalRoute exact path="/escrutinio" component={Escrutinio} />
           <Route exact path="/voter-count">
             <VoterCount />
           </Route>

--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -28,7 +28,8 @@ const FiscalizacionActions: React.FC = () => {
     <Layout backHref="/fiscalizacion-lookup">
       <IonContent className="ion-padding">
         <div className="flex flex-col items-center 1gap-4">
-        <Button routerLink="/voters" className="w-4/5">Votación</Button>
+          <Button routerLink="/voters" className="w-4/5">Votación</Button>
+          <Button routerLink="/escrutinio" className="w-4/5">Escrutinio</Button>
         </div>
       </IonContent>
     </Layout>


### PR DESCRIPTION
## Summary
- Add Escrutinio button on fiscalization actions screen
- Register Escrutinio route in app router

## Testing
- `npm run lint src/pages/FiscalizacionActions.tsx src/App.tsx`
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_68c22c8c72808329841625de7e67196c