### PR TITLE
feat: fetch candidate lists from API

### DIFF
--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -8,10 +8,9 @@ import {
 import { Button, Input } from '../components';
 import Layout from '../components/Layout';
 import { Camera, CameraResultType } from '@capacitor/camera';
-import { getDocs, collection, addDoc } from 'firebase/firestore';
-import { db } from '../firebase';
 import { useHistory } from 'react-router-dom';
 import { useFiscalData } from '../FiscalDataContext';
+import { getAuthHeaders } from '../utils/api';
 
 
 interface Lista {
@@ -31,7 +30,7 @@ const Escrutinio: React.FC = () => {
   const [resultado, setResultado] = useState<Record<string, number> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [listas, setListas] = useState<Lista[]>([]);
-  // Cargar las listas desde Firestore al iniciar
+  // Cargar las listas desde la API al iniciar
   useEffect(() => {
     if (!hasFiscalData) {
       const stored = localStorage.getItem('fiscalData');
@@ -46,12 +45,33 @@ const Escrutinio: React.FC = () => {
       }
     }
     const fetchListas = async () => {
-      const snapshot = await getDocs(collection(db, 'listas'));
-      const data: Lista[] = snapshot.docs.map((doc) => ({
-        id: doc.id,
-        ...(doc.data() as Omit<Lista, 'id'>)
-      }));
-      setListas(data);
+      try {
+        const res = await fetch('/api/fiscalizacion/listarCandidatos', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...getAuthHeaders()
+          },
+          body: JSON.stringify({})
+        });
+        if (!res.ok) throw new Error('Error al obtener listas');
+        const { data } = await res.json();
+        interface ApiLista {
+          identificador: string;
+          nombre: string;
+          nomenclatura: string;
+        }
+        const listas: Lista[] = (data as ApiLista[]).map(
+          ({ identificador, nombre, nomenclatura }) => ({
+            id: identificador,
+            lista: nombre,
+            nro_lista: nomenclatura
+          })
+        );
+        setListas(listas);
+      } catch (err) {
+        console.error(err);
+      }
     };
     fetchListas();
   }, [hasFiscalData, history, setFiscalData]);
@@ -89,35 +109,43 @@ const Escrutinio: React.FC = () => {
 
   // Al enviar
   const handleSubmit = async () => {
-  const datos: Record<string, number> = {};
+    const datos: Record<string, number> = {};
 
-  listas.forEach(l => {
-    datos[l.lista] = parseInt(valores[l.id], 10) || 0;
-  });
+    listas.forEach(l => {
+      datos[l.lista] = parseInt(valores[l.id], 10) || 0;
+    });
 
-  CAMPOS_ESPECIALES.forEach(key => {
-    datos[key] = parseInt(valores[key], 10) || 0;
-  });
+    CAMPOS_ESPECIALES.forEach(key => {
+      datos[key] = parseInt(valores[key], 10) || 0;
+    });
 
-  setResultado(datos);
+    setResultado(datos);
 
-  const mesaId = Number(localStorage.getItem('mesaId'));
-  const payload = {
-    mesa_id: mesaId,
-    datos,
-    fecha: new Date().toISOString(),
-    foto,
-    // podés sumar más campos si querés
+    const mesaId = Number(localStorage.getItem('mesaId'));
+    const payload = {
+      mesa_id: mesaId,
+      datos,
+      fecha: new Date().toISOString(),
+      foto,
+      // podés sumar más campos si querés
+    };
+    try {
+      const res = await fetch('/api/escrutinio', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...getAuthHeaders()
+        },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) throw new Error('Error al enviar escrutinio');
+      alert('Escrutinio enviado correctamente');
+      setFoto('');
+    } catch (err) {
+      alert('Error al guardar escrutinio');
+      console.error(err);
+    }
   };
-  try {
-    await addDoc(collection(db, 'escrutinio'), payload);
-    alert('Escrutinio enviado correctamente');
-    setFoto('');
-  } catch (err) {
-    alert('Error al guardar en Firestore');
-    console.error(err);
-  }
-};
 
 
   return (


### PR DESCRIPTION
## Summary
- replace Firestore query with authenticated POST to `/api/fiscalizacion/listarCandidatos`
- map API response to Lista interface and render `nro_lista - lista`
- submit escrutinio data via backend endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test.unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c23411f0348329be4d973a70115027