### PR TITLE
feat: add fiscalizacion listarCandidatos proxy

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ import mesaRoutes from './routes/mesas.js';
 import userRoutes from './routes/users.js';
 import escrutinioRoutes from './routes/escrutinio.js';
 import authRoutes from './routes/auth.js';
+import fiscalRoutes from './routes/fiscalizacion.js';
 import logger from './logger.js';
 
 const app = express();
@@ -51,6 +52,7 @@ app.use('/api/mesas', mesaRoutes);
 app.use('/api/auth', authRoutes);            // login
 app.use('/api/users', userRoutes);           // user management
 app.use('/api/escrutinio', escrutinioRoutes);
+app.use('/api/fiscalizacion', fiscalRoutes);
 
 // IMPORTANTE: no redirijas OPTIONS ni /api/auth/login en ningún middleware
 

--- a/server/routes/fiscalizacion.js
+++ b/server/routes/fiscalizacion.js
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.post('/listarCandidatos', async (req, res) => {
+  try {
+    const response = await fetch(
+      'https://api.lalibertadavanzacomuna7.com/api/fiscalizacion/listarCandidatos',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: req.headers.authorization || '',
+        },
+        body: JSON.stringify(req.body),
+      }
+    );
+
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
+    res.status(response.status).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch candidates' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add `/listarCandidatos` proxy route under `/api/fiscalizacion`
- register fiscalizacion routes in Express server

## Testing
- `npx eslint server/index.js server/routes/fiscalizacion.js`
- `npm run test.unit`
- `curl -i -X POST http://localhost:3000/api/fiscalizacion/listarCandidatos -H 'Content-Type: application/json' -H 'Authorization: Bearer test' -d '{}'`


------
https://chatgpt.com/codex/tasks/task_e_68c5a43970d88329af1ed62c62d68108