### PR TITLE
Remove candidate API fallback and add proxy reminder

### DIFF
--- a/src/pages/Escrutinio.test.tsx
+++ b/src/pages/Escrutinio.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { vi } from 'vitest';
+import Escrutinio from './Escrutinio';
+import { AuthProvider } from '../AuthContext';
+import { FiscalDataProvider } from '../FiscalDataContext';
+
+describe('Escrutinio', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  test('shows error if backend is unavailable', async () => {
+    const history = createMemoryHistory({ initialEntries: ['/escrutinio'] });
+    localStorage.setItem('fiscalData', '{}');
+
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('backend down'));
+
+    const { findByText } = render(
+      <AuthProvider>
+        <FiscalDataProvider>
+          <Router history={history}>
+            <Escrutinio />
+          </Router>
+        </FiscalDataProvider>
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/fiscalizacion/listarCandidatos',
+      expect.any(Object)
+    );
+    expect(
+      await findByText(/No se pudieron cargar las listas/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -30,6 +30,7 @@ const Escrutinio: React.FC = () => {
   const [resultado, setResultado] = useState<Record<string, number> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [listas, setListas] = useState<Lista[]>([]);
+  const [error, setError] = useState<string | null>(null);
   // Cargar las listas desde la API al iniciar
   useEffect(() => {
     if (!hasFiscalData) {
@@ -46,8 +47,7 @@ const Escrutinio: React.FC = () => {
     }
     const fetchListas = async () => {
       const url = '/api/fiscalizacion/listarCandidatos';
-      const fallbackUrl =
-        'https://api.lalibertadavanzacomuna7.com/api/fiscalizacion/listarCandidatos';
+      // El backend actúa como proxy; no consumas el dominio externo desde el navegador.
       const options: RequestInit = {
         method: 'POST',
         headers: {
@@ -94,20 +94,7 @@ const Escrutinio: React.FC = () => {
       } catch (err) {
         const error = err as Error & { status?: number };
         console.error('[fetchListas] Error:', error.message, error.status);
-        try {
-          const { data } = await fetchAndLog(fallbackUrl);
-          const listas: Lista[] = data.map(
-            ({ identificador, nombre, nomenclatura }) => ({
-              id: identificador,
-              lista: nombre,
-              nro_lista: nomenclatura
-            })
-          );
-          setListas(listas);
-        } catch (fallbackErr) {
-          const fbError = fallbackErr as Error & { status?: number };
-          console.error('[fetchListas] Fallback error:', fbError.message, fbError.status);
-        }
+        setError('No se pudieron cargar las listas. Verifica que el backend esté disponible.');
       }
     };
     fetchListas();
@@ -188,6 +175,7 @@ const Escrutinio: React.FC = () => {
   return (
     <Layout backHref="/fiscalizacion-acciones">
       <IonContent className="ion-padding">
+        {error && <p className="text-red-600 ion-margin-bottom">{error}</p>}
         {/* Inputs para todas las listas */}
         {listas.map((l) => (
           <IonItem key={l.id}>


### PR DESCRIPTION
## Summary
- remove external API fallback and rely solely on `/api/fiscalizacion/listarCandidatos`
- show a user-facing error when lists cannot be loaded
- add unit test for backend-down scenario

## Testing
- `npm run lint`
- `npm run test.unit`
- `npm run test.e2e` *(fails: Cypress could not verify that your server is running)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a43ac19883299f18276f90869639