### PR TITLE
Validate mesa and voter fields with DB error handling

### DIFF
--- a/server/routes/mesas.js
+++ b/server/routes/mesas.js
@@ -10,10 +10,27 @@ router.get('/', (req, res) => {
 
 router.post('/', (req, res) => {
   const { seccion, circuito, mesa } = req.body;
-  const info = db
-    .prepare('INSERT INTO mesas (seccion, circuito, mesa) VALUES (?, ?, ?)')
-    .run(seccion, circuito, mesa);
-  res.status(201).json({ id: info.lastInsertRowid });
+
+  const missing = [seccion, circuito, mesa].some(
+    (v) => v === undefined || v === null || v === ''
+  );
+  const invalidFormat =
+    !Number.isInteger(Number(seccion)) ||
+    !Number.isInteger(Number(circuito)) ||
+    !Number.isInteger(Number(mesa));
+
+  if (missing || invalidFormat) {
+    return res.status(400).json({ error: 'Datos de mesa inválidos' });
+  }
+
+  try {
+    const info = db
+      .prepare('INSERT INTO mesas (seccion, circuito, mesa) VALUES (?, ?, ?)')
+      .run(seccion, circuito, mesa);
+    res.status(201).json({ id: info.lastInsertRowid });
+  } catch (error) {
+    res.status(500).json({ error: 'Error al insertar mesa' });
+  }
 });
 
 export default router;

--- a/server/routes/voters.js
+++ b/server/routes/voters.js
@@ -23,10 +23,7 @@ router.post('/', (req, res) => {
     fechaEnviado,
     voto,
   } = req.body;
-  const stmt = db.prepare(`INSERT INTO votantes (
-    seccion, circuito, mesa, dni, nombre, apellido, numero_de_orden, genero, fechaEnviado, voto
-  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
-  const info = stmt.run(
+  const requiredMissing = [
     seccion,
     circuito,
     mesa,
@@ -34,22 +31,59 @@ router.post('/', (req, res) => {
     nombre,
     apellido,
     numero_de_orden,
-    genero,
-    fechaEnviado,
-    voto,
-  );
-  res.status(201).json({ id: info.lastInsertRowid });
+  ].some((v) => v === undefined || v === null || v === '');
+
+  const invalidFormat =
+    !Number.isInteger(Number(seccion)) ||
+    !Number.isInteger(Number(circuito)) ||
+    !Number.isInteger(Number(mesa)) ||
+    !/^[0-9]+$/.test(String(dni)) ||
+    typeof nombre !== 'string' ||
+    typeof apellido !== 'string' ||
+    !Number.isInteger(Number(numero_de_orden));
+
+  if (requiredMissing || invalidFormat) {
+    return res.status(400).json({ error: 'Datos de votante inválidos' });
+  }
+
+  try {
+    const stmt = db.prepare(`INSERT INTO votantes (
+    seccion, circuito, mesa, dni, nombre, apellido, numero_de_orden, genero, fechaEnviado, voto
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`);
+    const info = stmt.run(
+      seccion,
+      circuito,
+      mesa,
+      dni,
+      nombre,
+      apellido,
+      numero_de_orden,
+      genero,
+      fechaEnviado,
+      voto,
+    );
+    res.status(201).json({ id: info.lastInsertRowid });
+  } catch (error) {
+    res.status(500).json({ error: 'Error al insertar votante' });
+  }
 });
 
 router.put('/:id/voto', (req, res) => {
   const { id } = req.params;
   const { voto } = req.body;
-  const stmt = db.prepare('UPDATE votantes SET voto = ? WHERE id = ?');
-  const info = stmt.run(voto, id);
-  if (info.changes === 0) {
-    res.status(404).json({ error: 'Votante no encontrado' });
-  } else {
-    res.json({ updated: info.changes });
+  if (voto === undefined || voto === null) {
+    return res.status(400).json({ error: 'Dato voto inválido' });
+  }
+  try {
+    const stmt = db.prepare('UPDATE votantes SET voto = ? WHERE id = ?');
+    const info = stmt.run(voto, id);
+    if (info.changes === 0) {
+      res.status(404).json({ error: 'Votante no encontrado' });
+    } else {
+      res.json({ updated: info.changes });
+    }
+  } catch (error) {
+    res.status(500).json({ error: 'Error al actualizar voto' });
   }
 });
 


### PR DESCRIPTION
## Summary
- validate required mesa fields and catch DB errors
- enforce voter field validation and wrap DB operations in try/catch
- guard vote updates against invalid data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test.unit` *(fails: Voters API creates a voter via POST)*

------
https://chatgpt.com/codex/tasks/task_e_68c71af719f4832999295abb9bbcfd9f