### PR TITLE
handle acta photo in actions page and send from shared storage

### DIFF
--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useEffect, useRef, ChangeEvent } from 'react';
+import React, { useState, useEffect } from 'react';
 import { IonContent, IonItem, IonLabel, IonText } from '@ionic/react';
 import { Button, Input } from '../components';
 import Layout from '../components/Layout';
-import { Camera, CameraResultType } from '@capacitor/camera';
 import { useHistory } from 'react-router-dom';
 import { useFiscalData } from '../FiscalDataContext';
 
@@ -54,10 +53,8 @@ const Escrutinio: React.FC = () => {
 
   const [listas, setListas] = useState<Lista[]>([]);
   const [valores, setValores] = useState<Record<string, string>>({});
-  const [foto, setFoto] = useState('');
   const [resultado, setResultado] = useState<Record<string, number> | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Cargar listas al iniciar (requiere token)
   useEffect(() => {
@@ -134,26 +131,6 @@ const Escrutinio: React.FC = () => {
     setValores((prev) => ({ ...prev, [id]: value }));
   };
 
-  const handleFoto = async () => {
-    try {
-      const photo = await Camera.getPhoto({
-        resultType: CameraResultType.DataUrl,
-        quality: 80,
-      });
-      if (photo.dataUrl) setFoto(photo.dataUrl);
-    } catch {
-      fileInputRef.current?.click();
-    }
-  };
-
-  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => setFoto(reader.result as string);
-    reader.readAsDataURL(file);
-  };
-
   const handleSubmit = async () => {
     setError(null);
 
@@ -169,12 +146,13 @@ const Escrutinio: React.FC = () => {
     setResultado(datos);
 
     const mesaId = Number(localStorage.getItem('mesaId'));
-    const payload = {
+    const foto = localStorage.getItem('fotoActa');
+    const payload: Record<string, unknown> = {
       mesa_id: mesaId,
       datos,
       fecha: new Date().toISOString(),
-      foto,
     };
+    if (foto) payload.foto = foto;
 
     const token = localStorage.getItem('token') || '';
     if (!token) {
@@ -204,7 +182,7 @@ const Escrutinio: React.FC = () => {
       }
 
       alert('Escrutinio enviado correctamente');
-      setFoto('');
+      localStorage.removeItem('fotoActa');
     } catch (e: unknown) {
           const msg = toErrorMessage(e);
           console.error('[escrutinio] submit error:', e);
@@ -244,21 +222,6 @@ const Escrutinio: React.FC = () => {
             />
           </IonItem>
         ))}
-
-        {/* Subir foto */}
-        <IonItem>
-          <IonLabel position="stacked">Foto (opcional)</IonLabel>
-          <Button onClick={handleFoto}>Tomar/Subir Foto</Button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleFileChange}
-            title="Subir foto de acta"
-          />
-          {foto && <img src={foto} alt="Foto de acta" className="max-w-xs mt-2 rounded shadow" />}
-        </IonItem>
 
         <Button expand="block" className="ion-margin-top" onClick={handleSubmit}>
           Enviar

--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -1,13 +1,48 @@
-import { IonContent } from '@ionic/react';
+import { IonContent, IonItem, IonLabel } from '@ionic/react';
 import Layout from '../components/Layout';
 import { Button } from '../components';
 import { useFiscalData } from '../FiscalDataContext';
-import { useEffect } from 'react';
+import { useEffect, useState, useRef, ChangeEvent } from 'react';
 import { useHistory } from 'react-router-dom';
+import { Camera, CameraResultType } from '@capacitor/camera';
 
 const FiscalizacionActions: React.FC = () => {
   const history = useHistory();
   const { hasFiscalData, setFiscalData } = useFiscalData();
+  const [foto, setFoto] = useState<string>(localStorage.getItem('fotoActa') || '');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFoto = async () => {
+    try {
+      const photo = await Camera.getPhoto({
+        resultType: CameraResultType.DataUrl,
+        quality: 80,
+      });
+      if (photo.dataUrl) {
+        setFoto(photo.dataUrl);
+        localStorage.setItem('fotoActa', photo.dataUrl);
+      }
+    } catch {
+      fileInputRef.current?.click();
+    }
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      setFoto(dataUrl);
+      localStorage.setItem('fotoActa', dataUrl);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleClearFoto = () => {
+    setFoto('');
+    localStorage.removeItem('fotoActa');
+  };
 
   useEffect(() => {
     if (!hasFiscalData) {
@@ -27,7 +62,27 @@ const FiscalizacionActions: React.FC = () => {
   return (
     <Layout backHref="/fiscalizacion-lookup">
       <IonContent className="ion-padding">
-        <div className="flex flex-col items-center 1gap-4">
+        <IonItem>
+          <IonLabel position="stacked">Foto del acta</IonLabel>
+          <Button onClick={handleFoto}>Tomar/Subir Foto</Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileChange}
+            title="Subir foto del acta"
+          />
+          {foto && (
+            <div className="flex flex-col items-center">
+              <img src={foto} alt="Foto del acta" className="max-w-xs mt-2 rounded shadow" />
+              <Button size="small" color="danger" className="mt-2" onClick={handleClearFoto}>
+                Borrar foto
+              </Button>
+            </div>
+          )}
+        </IonItem>
+        <div className="flex flex-col items-center 1gap-4 mt-4">
           <Button routerLink="/voters" className="w-4/5">Votación</Button>
           <Button routerLink="/escrutinio" className="w-4/5">Escrutinio</Button>
         </div>


### PR DESCRIPTION
## Summary
- use a shared `fotoActa` from localStorage when sending escrutinio data
- allow capturing and managing acta photo on fiscalization actions screen

## Testing
- `npm run test.unit` *(fails: Voters API creates a voter via POST, Escrutinio shows error if backend is unavailable)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c75676bb1083299117c9ae59daf46d