### PR TITLE
feat: default Button to primary color

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,8 +3,20 @@ import { IonButton } from '@ionic/react';
 
 export type ButtonProps = React.ComponentProps<typeof IonButton>;
 
-const Button: React.FC<ButtonProps> = ({ className = '', ...rest }) => {
-  return <IonButton className={`px-4 py-2 rounded ${className}`} {...rest} />;
+const Button: React.FC<ButtonProps> = ({
+  className = '',
+  color = 'primary',
+  style,
+  ...rest
+}) => {
+  return (
+    <IonButton
+      color={color}
+      className={`px-4 py-2 rounded ${className}`}
+      style={style}
+      {...rest}
+    />
+  );
 };
 
 export default Button;


### PR DESCRIPTION
## Summary
- default Button component to Ion `primary` color
- support overriding color via props or custom classes/styles

## Testing
- `npm run lint` (fails: React Hook "useFiscalData" is called conditionally)
- `npm run test.unit` (fails: 9 failing tests, e.g. cannot read properties of undefined)
- `npm run test.e2e` (fails: missing Xvfb)


------
https://chatgpt.com/codex/tasks/task_e_68c77a7b873c8329865b4b6bcc366a27