### PR TITLE
refactor: remove voter stats from layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   IonPage,
   IonHeader,
@@ -7,16 +7,12 @@ import {
   IonButtons,
   IonButton,
   IonFooter,
-  IonIcon,
-  IonModal,
-  IonContent
+  IonIcon
 } from '@ionic/react';
 import { chevronBackOutline } from 'ionicons/icons';
 import { useHistory } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
-import { voterDB } from '../voterDB';
 import { useFiscalData } from '../FiscalDataContext';
-import type { FiscalData } from '../FiscalDataContext';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -27,34 +23,10 @@ interface LayoutProps {
 const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
   const { logout } = useAuth();
   const history = useHistory();
-  const [showStats, setShowStats] = useState(false);
-  const [totalVoters, setTotalVoters] = useState(0);
-  const [votedCount, setVotedCount] = useState(0);
-  let fiscalData: FiscalData | null = null;
-  try {
-    ({ fiscalData } = useFiscalData());
-  } catch {
-    fiscalData = null;
-  }
+  const { fiscalData } = useFiscalData();
   const title = fiscalData
     ? `${fiscalData.persona.nombre} ${fiscalData.persona.apellido} – ${fiscalData.tipo_fiscal} – ${fiscalData.zona}`
     : 'Fiscalizacion App';
-
-  useEffect(() => {
-    if (!showStats) {
-      setTotalVoters(0);
-      setVotedCount(0);
-    }
-  }, [showStats]);
-
-  const handleStats = async () => {
-    const all = await voterDB.voters.toArray();
-    const total = all.length;
-    const voted = all.filter(v => v.voto).length;
-    setTotalVoters(total);
-    setVotedCount(voted);
-    setShowStats(true);
-  };
 
   const handleLogout = async () => {
     await logout();
@@ -79,21 +51,10 @@ const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
           )}
           <IonTitle className="font-bold text-lg">{title}</IonTitle>
           <IonButtons slot="end">
-            <IonButton color="primary" onClick={handleStats}>Estadísticas</IonButton>
             <IonButton color="primary" onClick={handleLogout}>Desloguearse</IonButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>
-      <IonModal isOpen={showStats} onDidDismiss={() => setShowStats(false)}>
-        <IonContent className="p-4">
-          <p>Cantidad de votantes: {totalVoters}</p>
-          <p>Cantidad que votó: {votedCount}</p>
-          <p>
-            Porcentaje: {totalVoters ? ((votedCount / totalVoters) * 100).toFixed(2) : '0.00'}%
-          </p>
-          <IonButton onClick={() => setShowStats(false)}>Cerrar</IonButton>
-        </IonContent>
-      </IonModal>
       {children}
       {footer && <IonFooter>{footer}</IonFooter>}
     </IonPage>


### PR DESCRIPTION
## Summary
- remove voter statistics functionality from layout component
- clean up unused imports and hooks

## Testing
- `npm run lint src/components/Layout.tsx`
- `npm run build` *(fails: Cannot find name 'useState' in src/pages/FiscalizacionActions.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c77a7f73d0832990d95369b82938bb