### PR TITLE
Align fiscalizacion photo button styling

### DIFF
--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -69,7 +69,9 @@ const FiscalizacionActions: React.FC = () => {
           
         </IonItem>
         <div className="flex flex-col items-center gap-4  w-4/5 mx-auto mt-4">
-          <Button onClick={handleFoto}>Tomar/Subir Foto</Button>
+          <Button onClick={handleFoto} className="flex flex-col items-center w-4/5">
+            Tomar/Subir Foto
+          </Button>
           <input
             ref={fileInputRef}
             type="file"


### PR DESCRIPTION
## Summary
- align the photo capture button styling with the other action buttons on the fiscalización actions page for consistent widths

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d16ccd90cc8329bb554e4ef5b1aea1