### PR TITLE
Ensure layout title always starts with app name

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -21,14 +21,18 @@ interface LayoutProps {
   backHref?: string;
 }
 function formatTitle(fd?: FiscalData | null) {
-  if (!fd) return 'Fiscalizacion App';
-  const nombre   = fd.persona?.nombre   ?? '';
+  const baseTitle = 'Fiscalizacion App';
+  if (!fd) return baseTitle;
+
+  const nombre = fd.persona?.nombre ?? '';
   const apellido = fd.persona?.apellido ?? '';
-  const tipo     = fd.tipo_fiscal       ?? '';
-  const zona     = fd.zona              ?? '';
-  const left = [nombre, apellido].filter(Boolean).join(' ').trim();
-  const parts = [left, tipo, zona].filter(Boolean);
-  return parts.length ? parts.join(' – ') : 'Fiscalizacion App';
+  const tipo = fd.tipo_fiscal ?? '';
+  const zona = fd.zona ?? '';
+
+  const persona = [nombre, apellido].filter(Boolean).join(' ').trim();
+  const details = [persona, tipo, zona].filter(Boolean);
+
+  return details.length ? `${baseTitle} – ${details.join(' – ')}` : baseTitle;
 }
 const Layout: React.FC<LayoutProps> = ({ children, footer, backHref }) => {
   const { logout } = useAuth();


### PR DESCRIPTION
## Summary
- ensure the layout title always begins with "Fiscalizacion App"
- append available fiscal details to the title only when present

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e088f0b17c8329b91ebfe04492084f