### PR TITLE
Normalize legacy fiscal data cache and add Layout tests

### DIFF
--- a/src/FiscalDataContext.test.tsx
+++ b/src/FiscalDataContext.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  FiscalDataProvider,
+  useFiscalData,
+  type FiscalData,
+} from './FiscalDataContext';
+
+const Consumer: React.FC = () => {
+  const { fiscalData, hasFiscalData } = useFiscalData();
+  return (
+    <div>
+      <div data-testid="has-data">{String(hasFiscalData)}</div>
+      <div data-testid="apellidos">{fiscalData?.apellidos_miembro ?? ''}</div>
+      <div data-testid="nombres">{fiscalData?.nombres_miembro ?? ''}</div>
+      <div data-testid="tipo">{fiscalData?.nombre_tipo_miembro ?? ''}</div>
+      <div data-testid="zona">{fiscalData?.nombre_zona ?? ''}</div>
+    </div>
+  );
+};
+
+describe('FiscalDataProvider hydration', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('hydrates data already in the new format', () => {
+    const payload: FiscalData = {
+      apellidos_miembro: 'Doe',
+      nombres_miembro: 'Jane',
+      nombre_tipo_miembro: 'General',
+      nombre_zona: 'Zona 1',
+    };
+    localStorage.setItem('fiscalData', JSON.stringify(payload));
+
+    render(
+      <FiscalDataProvider>
+        <Consumer />
+      </FiscalDataProvider>,
+    );
+
+    expect(screen.getByTestId('has-data').textContent).toBe('true');
+    expect(screen.getByTestId('apellidos').textContent).toBe('Doe');
+    expect(screen.getByTestId('nombres').textContent).toBe('Jane');
+    expect(screen.getByTestId('tipo').textContent).toBe('General');
+    expect(screen.getByTestId('zona').textContent).toBe('Zona 1');
+  });
+
+  it('migrates legacy cached data to the new format', async () => {
+    const legacyPayload = {
+      persona: 'Doe, Jane',
+      tipo_fiscal: 'Suplente',
+      zona: 'Zona 9',
+    };
+    localStorage.setItem('fiscalData', JSON.stringify(legacyPayload));
+
+    render(
+      <FiscalDataProvider>
+        <Consumer />
+      </FiscalDataProvider>,
+    );
+
+    expect(screen.getByTestId('has-data').textContent).toBe('true');
+    expect(screen.getByTestId('apellidos').textContent).toBe('Doe');
+    expect(screen.getByTestId('nombres').textContent).toBe('Jane');
+    expect(screen.getByTestId('tipo').textContent).toBe('Suplente');
+    expect(screen.getByTestId('zona').textContent).toBe('Zona 9');
+
+    await waitFor(() => {
+      const stored = localStorage.getItem('fiscalData');
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.apellidos_miembro).toBe('Doe');
+      expect(parsed.nombres_miembro).toBe('Jane');
+      expect(parsed.nombre_tipo_miembro).toBe('Suplente');
+      expect(parsed.nombre_zona).toBe('Zona 9');
+    });
+  });
+});

--- a/src/FiscalDataContext.tsx
+++ b/src/FiscalDataContext.tsx
@@ -1,12 +1,154 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 export interface FiscalData {
   apellidos_miembro?: string | null;
   nombres_miembro?: string | null;
   nombre_tipo_miembro?: string | null;
   nombre_zona?: string | null;
+  persona?: unknown;
   [key: string]: unknown;
 }
+
+interface MemberNameParts {
+  apellidos?: string;
+  nombres?: string;
+  displayName?: string;
+}
+
+const getTrimmedString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const deriveNamesFromPersona = (persona: unknown): MemberNameParts => {
+  if (!persona) return {};
+
+  if (typeof persona === 'string') {
+    const trimmed = persona.trim();
+    if (!trimmed) return {};
+
+    const commaParts = trimmed.split(',');
+    if (commaParts.length >= 2) {
+      const apellidos = commaParts[0]?.trim();
+      const nombres = commaParts.slice(1).join(',').trim();
+      return {
+        apellidos: apellidos || undefined,
+        nombres: nombres || undefined,
+        displayName: trimmed,
+      };
+    }
+
+    const parts = trimmed.split(/\s+/);
+    if (parts.length >= 2) {
+      const apellidos = parts.slice(-1).join(' ').trim();
+      const nombres = parts.slice(0, -1).join(' ').trim();
+      return {
+        apellidos: apellidos || undefined,
+        nombres: nombres || undefined,
+        displayName: trimmed,
+      };
+    }
+
+    return { apellidos: trimmed, displayName: trimmed };
+  }
+
+  if (typeof persona === 'object') {
+    const personaObj = persona as Record<string, unknown>;
+    const apellidos =
+      getTrimmedString(personaObj['apellidos_miembro']) ||
+      getTrimmedString(personaObj['apellidos']) ||
+      getTrimmedString(personaObj['apellido']);
+    const nombres =
+      getTrimmedString(personaObj['nombres_miembro']) ||
+      getTrimmedString(personaObj['nombres']) ||
+      getTrimmedString(personaObj['nombre']);
+
+    const displayName =
+      getTrimmedString(personaObj['nombre_completo']) ||
+      [nombres, apellidos].filter(Boolean).join(' ').trim() ||
+      undefined;
+
+    return {
+      apellidos: apellidos || undefined,
+      nombres: nombres || undefined,
+      displayName,
+    };
+  }
+
+  return {};
+};
+
+export const getMemberNameParts = (
+  data?: FiscalData | (Record<string, unknown> & { persona?: unknown }) | null,
+): MemberNameParts => {
+  if (!data) return {};
+
+  const record = data as Record<string, unknown> & { persona?: unknown };
+  const apellidos = getTrimmedString(record['apellidos_miembro']);
+  const nombres = getTrimmedString(record['nombres_miembro']);
+
+  if (apellidos && nombres) {
+    return { apellidos, nombres, displayName: `${apellidos} ${nombres}`.trim() };
+  }
+
+  const legacy = deriveNamesFromPersona(record.persona);
+
+  return {
+    apellidos: apellidos || legacy.apellidos,
+    nombres: nombres || legacy.nombres,
+    displayName:
+      (apellidos && nombres && `${apellidos} ${nombres}`.trim()) ||
+      legacy.displayName ||
+      [legacy.apellidos, legacy.nombres].filter(Boolean).join(' ').trim() ||
+      undefined,
+  };
+};
+
+export const normalizeFiscalData = (value: unknown): FiscalData | null => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const raw = value as Record<string, unknown>;
+  const normalized: Record<string, unknown> = { ...raw };
+
+  const { apellidos, nombres } = getMemberNameParts(
+    raw as Record<string, unknown> & { persona?: unknown },
+  );
+
+  if (apellidos) {
+    normalized['apellidos_miembro'] = apellidos;
+  }
+
+  if (nombres) {
+    normalized['nombres_miembro'] = nombres;
+  }
+
+  const tipo =
+    getTrimmedString(raw['nombre_tipo_miembro']) ||
+    getTrimmedString(raw['tipo_fiscal']);
+
+  if (tipo) {
+    normalized['nombre_tipo_miembro'] = tipo;
+  }
+
+  const zona =
+    getTrimmedString(raw['nombre_zona']) || getTrimmedString(raw['zona']);
+
+  if (zona) {
+    normalized['nombre_zona'] = zona;
+  }
+
+  return normalized as FiscalData;
+};
 
 interface FiscalDataContextValue {
   fiscalData: FiscalData | null;
@@ -21,10 +163,36 @@ const FiscalDataContext = createContext<FiscalDataContextValue | undefined>(
 export const FiscalDataProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [fiscalData, setFiscalData] = useState<FiscalData | null>(() => {
-    const stored = localStorage.getItem('fiscalData');
-    return stored ? (JSON.parse(stored) as FiscalData) : null;
-  });
+  const initialValue = useMemo(() => {
+    try {
+      const stored = localStorage.getItem('fiscalData');
+      if (!stored) return null;
+      return normalizeFiscalData(JSON.parse(stored));
+    } catch (error) {
+      console.warn('Failed to parse stored fiscal data', error);
+      return null;
+    }
+  }, []);
+
+  const [fiscalData, setFiscalDataState] = useState<FiscalData | null>(
+    initialValue,
+  );
+
+  const setFiscalData = useCallback(
+    (value: React.SetStateAction<FiscalData | null>) => {
+      setFiscalDataState((prev) => {
+        const nextValue =
+          typeof value === 'function' ? (value as (arg: FiscalData | null) => FiscalData | null)(prev) : value;
+
+        if (nextValue === null) {
+          return null;
+        }
+
+        return normalizeFiscalData(nextValue) ?? null;
+      });
+    },
+    [],
+  );
 
   useEffect(() => {
     if (fiscalData === null) {

--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import Layout, { formatTitle } from './Layout';
+import {
+  FiscalDataProvider,
+  type FiscalData,
+} from '../FiscalDataContext';
+
+vi.mock('../AuthContext', () => ({
+  useAuth: () => ({
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return {
+    ...actual,
+    useHistory: () => ({ push: vi.fn() }),
+  };
+});
+
+describe('formatTitle', () => {
+  it('renders the base title when no fiscal data is provided', () => {
+    expect(formatTitle()).toBe('Fiscalizacion App');
+  });
+
+  it('uses the new fields when available', () => {
+    expect(
+      formatTitle({
+        apellidos_miembro: 'Doe',
+        nombres_miembro: 'Jane',
+      }),
+    ).toBe('Fiscalizacion App – Doe Jane');
+  });
+
+  it('falls back to legacy persona strings', () => {
+    expect(
+      formatTitle({
+        persona: 'Doe, Jane',
+      } as FiscalData),
+    ).toBe('Fiscalizacion App – Doe Jane');
+  });
+});
+
+describe('Layout title rendering', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders title for data already normalized', () => {
+    localStorage.setItem(
+      'fiscalData',
+      JSON.stringify({
+        apellidos_miembro: 'Doe',
+        nombres_miembro: 'Jane',
+      }),
+    );
+
+    render(
+      <FiscalDataProvider>
+        <Layout>Children</Layout>
+      </FiscalDataProvider>,
+    );
+
+    expect(
+      screen.getByText('Fiscalizacion App – Doe Jane'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders title when only legacy cached data is present', () => {
+    localStorage.setItem(
+      'fiscalData',
+      JSON.stringify({
+        persona: 'Doe, Jane',
+      }),
+    );
+
+    render(
+      <FiscalDataProvider>
+        <Layout>Children</Layout>
+      </FiscalDataProvider>,
+    );
+
+    expect(
+      screen.getByText('Fiscalizacion App – Doe Jane'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,7 +12,7 @@ import {
 import { chevronBackOutline } from 'ionicons/icons';
 import { useHistory } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
-import { useFiscalData } from '../FiscalDataContext';
+import { getMemberNameParts, useFiscalData } from '../FiscalDataContext';
 import type { FiscalData } from '../FiscalDataContext';
 
 interface LayoutProps {
@@ -20,15 +20,18 @@ interface LayoutProps {
   footer?: React.ReactNode;
   backHref?: string;
 }
-function formatTitle(fd?: FiscalData | null) {
+export function formatTitle(fd?: FiscalData | null) {
   const baseTitle = 'Fiscalizacion App';
   if (!fd) return baseTitle;
 
-  const apellidos = typeof fd.apellidos_miembro === 'string' ? fd.apellidos_miembro.trim() : '';
-  const nombres = typeof fd.nombres_miembro === 'string' ? fd.nombres_miembro.trim() : '';
+  const { apellidos, nombres, displayName } = getMemberNameParts(fd);
 
   if (apellidos && nombres) {
     return `${baseTitle} – ${apellidos} ${nombres}`;
+  }
+
+  if (displayName) {
+    return `${baseTitle} – ${displayName}`;
   }
 
   return baseTitle;


### PR DESCRIPTION
## Summary
- normalize cached fiscal data and migrate legacy persona/tipo_fiscal/zona fields when hydrating the context
- update the Layout title helper to support both normalized and legacy fiscal data payloads
- add unit tests covering context hydration and Layout titles for new and legacy data shapes

## Testing
- npx vitest run src/FiscalDataContext.test.tsx src/components/Layout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1ab921a548329bd28d3f7f437a7e5