### PR TITLE
Update layout title formatting with comma-separated names

### DIFF
--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -34,7 +34,7 @@ describe('formatTitle', () => {
         apellidos_miembro: 'Doe',
         nombres_miembro: 'Jane',
       }),
-    ).toBe('Fiscalizacion App – Doe Jane');
+    ).toBe('Fiscalizacion App – Doe, Jane');
   });
 
   it('falls back to legacy persona strings', () => {
@@ -42,7 +42,7 @@ describe('formatTitle', () => {
       formatTitle({
         persona: 'Doe, Jane',
       } as FiscalData),
-    ).toBe('Fiscalizacion App – Doe Jane');
+    ).toBe('Fiscalizacion App – Doe, Jane');
   });
 });
 
@@ -67,7 +67,7 @@ describe('Layout title rendering', () => {
     );
 
     expect(
-      screen.getByText('Fiscalizacion App – Doe Jane'),
+      screen.getByText('Fiscalizacion App – Doe, Jane'),
     ).toBeInTheDocument();
   });
 
@@ -86,7 +86,7 @@ describe('Layout title rendering', () => {
     );
 
     expect(
-      screen.getByText('Fiscalizacion App – Doe Jane'),
+      screen.getByText('Fiscalizacion App – Doe, Jane'),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -24,14 +24,23 @@ export function formatTitle(fd?: FiscalData | null) {
   const baseTitle = 'Fiscalizacion App';
   if (!fd) return baseTitle;
 
+  const normalizedApellidos =
+    typeof fd.apellidos_miembro === 'string' ? fd.apellidos_miembro.trim() : '';
+  const normalizedNombres =
+    typeof fd.nombres_miembro === 'string' ? fd.nombres_miembro.trim() : '';
+
   const { apellidos, nombres, displayName } = getMemberNameParts(fd);
 
-  if (apellidos && nombres) {
-    return `${baseTitle} – ${apellidos} ${nombres}`;
+  if (normalizedApellidos && normalizedNombres) {
+    return `${baseTitle} – ${normalizedApellidos}, ${normalizedNombres}`;
   }
 
   if (displayName) {
     return `${baseTitle} – ${displayName}`;
+  }
+
+  if (apellidos && nombres) {
+    return `${baseTitle} – ${apellidos} ${nombres}`;
   }
 
   return baseTitle;


### PR DESCRIPTION
## Summary
- adjust `formatTitle` to render comma-separated normalized names while keeping display name fallback
- update layout title unit tests to expect the new formatting

## Testing
- npm run test.unit -- src/components/Layout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1e4cb87648329843ba485282aae21