### PR TITLE
Update layout titles to show member name only

### DIFF
--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -34,7 +34,7 @@ describe('formatTitle', () => {
         apellidos_miembro: 'Doe',
         nombres_miembro: 'Jane',
       }),
-    ).toBe('Fiscalizacion App – Doe, Jane');
+    ).toBe('Doe, Jane');
   });
 
   it('falls back to legacy persona strings', () => {
@@ -42,7 +42,7 @@ describe('formatTitle', () => {
       formatTitle({
         persona: 'Doe, Jane',
       } as FiscalData),
-    ).toBe('Fiscalizacion App – Doe, Jane');
+    ).toBe('Doe, Jane');
   });
 });
 
@@ -66,9 +66,7 @@ describe('Layout title rendering', () => {
       </FiscalDataProvider>,
     );
 
-    expect(
-      screen.getByText('Fiscalizacion App – Doe, Jane'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Doe, Jane')).toBeInTheDocument();
   });
 
   it('renders title when only legacy cached data is present', () => {
@@ -85,8 +83,6 @@ describe('Layout title rendering', () => {
       </FiscalDataProvider>,
     );
 
-    expect(
-      screen.getByText('Fiscalizacion App – Doe, Jane'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Doe, Jane')).toBeInTheDocument();
   });
 });

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -20,6 +20,14 @@ interface LayoutProps {
   footer?: React.ReactNode;
   backHref?: string;
 }
+const joinMemberName = (apellidos?: string, nombres?: string) => {
+  if (apellidos && nombres) {
+    return `${apellidos}, ${nombres}`;
+  }
+
+  return apellidos || nombres || '';
+};
+
 export function formatTitle(fd?: FiscalData | null) {
   const baseTitle = 'Fiscalizacion App';
   if (!fd) return baseTitle;
@@ -31,16 +39,20 @@ export function formatTitle(fd?: FiscalData | null) {
 
   const { apellidos, nombres, displayName } = getMemberNameParts(fd);
 
-  if (normalizedApellidos && normalizedNombres) {
-    return `${baseTitle} – ${normalizedApellidos}, ${normalizedNombres}`;
+  if (normalizedApellidos || normalizedNombres) {
+    const normalizedTitle = joinMemberName(normalizedApellidos, normalizedNombres);
+    if (normalizedTitle) {
+      return normalizedTitle;
+    }
   }
 
   if (displayName) {
-    return `${baseTitle} – ${displayName}`;
+    return displayName;
   }
 
-  if (apellidos && nombres) {
-    return `${baseTitle} – ${apellidos} ${nombres}`;
+  const fallbackTitle = joinMemberName(apellidos, nombres);
+  if (fallbackTitle) {
+    return fallbackTitle;
   }
 
   return baseTitle;


### PR DESCRIPTION
## Summary
- update the layout title formatter to return only the member name values
- align layout unit tests with the new title output

## Testing
- npm run test.unit -- src/components/Layout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2bde8c09c8329ac9805e2169124db