### PR TITLE
Ensure fiscal names are derived from nested buscarFiscal payloads

### DIFF
--- a/src/FiscalDataContext.tsx
+++ b/src/FiscalDataContext.tsx
@@ -28,6 +28,80 @@ const getTrimmedString = (value: unknown): string | undefined => {
   return trimmed.length > 0 ? trimmed : undefined;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const NAME_FIELD_KEYS = [
+  'apellidos_miembro',
+  'apellidos',
+  'apellido',
+  'nombres_miembro',
+  'nombres',
+  'nombre',
+  'apellido_miembro',
+  'nombre_miembro',
+];
+
+const METADATA_FIELD_KEYS = ['nombre_tipo_miembro', 'tipo_fiscal', 'nombre_zona', 'zona'];
+
+const findNestedPersona = (value: unknown): Record<string, unknown> | undefined => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findNestedPersona(item);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if ('persona' in value && isRecord(value['persona'])) {
+    return value['persona'] as Record<string, unknown>;
+  }
+
+  for (const nested of Object.values(value)) {
+    const found = findNestedPersona(nested);
+    if (found) return found;
+  }
+
+  return undefined;
+};
+
+const hasNameFields = (record: Record<string, unknown>): boolean => {
+  return NAME_FIELD_KEYS.some((key) => {
+    const value = record[key];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+};
+
+const findNameSource = (value: unknown): Record<string, unknown> | undefined => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findNameSource(item);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (hasNameFields(value)) {
+    return value;
+  }
+
+  for (const nested of Object.values(value)) {
+    const found = findNameSource(nested);
+    if (found) return found;
+  }
+
+  return undefined;
+};
+
 const deriveNamesFromPersona = (persona: unknown): MemberNameParts => {
   if (!persona) return {};
 
@@ -120,8 +194,22 @@ export const normalizeFiscalData = (value: unknown): FiscalData | null => {
   const raw = value as Record<string, unknown>;
   const normalized: Record<string, unknown> = { ...raw };
 
+  const nestedPersona = findNestedPersona(raw);
+  if (nestedPersona) {
+    normalized['persona'] = nestedPersona;
+  }
+
+  const nameSource = findNameSource(raw);
+  if (nameSource) {
+    for (const key of [...NAME_FIELD_KEYS, ...METADATA_FIELD_KEYS]) {
+      if (normalized[key] === undefined && key in nameSource) {
+        normalized[key] = nameSource[key];
+      }
+    }
+  }
+
   const { apellidos, nombres } = getMemberNameParts(
-    raw as Record<string, unknown> & { persona?: unknown },
+    normalized as Record<string, unknown> & { persona?: unknown },
   );
 
   if (apellidos) {
@@ -133,15 +221,15 @@ export const normalizeFiscalData = (value: unknown): FiscalData | null => {
   }
 
   const tipo =
-    getTrimmedString(raw['nombre_tipo_miembro']) ||
-    getTrimmedString(raw['tipo_fiscal']);
+    getTrimmedString(normalized['nombre_tipo_miembro']) ||
+    getTrimmedString(normalized['tipo_fiscal']);
 
   if (tipo) {
     normalized['nombre_tipo_miembro'] = tipo;
   }
 
   const zona =
-    getTrimmedString(raw['nombre_zona']) || getTrimmedString(raw['zona']);
+    getTrimmedString(normalized['nombre_zona']) || getTrimmedString(normalized['zona']);
 
   if (zona) {
     normalized['nombre_zona'] = zona;

--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -1,18 +1,41 @@
 import { IonContent, IonItem, IonLabel } from '@ionic/react';
 import Layout from '../components/Layout';
 import { Button } from '../components';
-import { useFiscalData } from '../FiscalDataContext';
+import { getMemberNameParts, useFiscalData } from '../FiscalDataContext';
 import type { FiscalData } from '../FiscalDataContext';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Camera, CameraResultType } from '@capacitor/camera';
 import type { ChangeEvent } from 'react';
 
 const FiscalizacionActions: React.FC = () => {
   const history = useHistory();
-  const { hasFiscalData, setFiscalData } = useFiscalData();
+  const { fiscalData, hasFiscalData, setFiscalData } = useFiscalData();
   const [foto, setFoto] = useState<string>(localStorage.getItem('fotoActa') || '');
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const memberName = useMemo(() => {
+    if (!fiscalData) return '';
+    const { apellidos, nombres, displayName } = getMemberNameParts(fiscalData);
+    if (displayName) return displayName;
+    if (apellidos && nombres) return `${apellidos}, ${nombres}`;
+    return apellidos || nombres || '';
+  }, [fiscalData]);
+
+  const memberType = useMemo(() => {
+    if (!fiscalData) return '';
+    const value =
+      typeof fiscalData.nombre_tipo_miembro === 'string'
+        ? fiscalData.nombre_tipo_miembro.trim()
+        : '';
+    return value;
+  }, [fiscalData]);
+
+  const memberZone = useMemo(() => {
+    if (!fiscalData) return '';
+    const value = typeof fiscalData.nombre_zona === 'string' ? fiscalData.nombre_zona.trim() : '';
+    return value;
+  }, [fiscalData]);
 
   const handleFoto = async () => {
     try {
@@ -64,9 +87,23 @@ const FiscalizacionActions: React.FC = () => {
   return (
     <Layout backHref="/fiscalizacion-lookup">
       <IonContent className="ion-padding">
+        {fiscalData && (
+          <IonItem lines="none" className="ion-margin-bottom rounded-lg bg-gray-100">
+            <IonLabel>
+              <h2 className="font-semibold text-base">Fiscal asignado</h2>
+              {memberName && <p className="text-sm">{memberName}</p>}
+              {memberType && <p className="text-sm text-gray-600">{memberType}</p>}
+              {memberZone && (
+                <p className="text-sm text-gray-600">
+                  Zona: <span className="font-medium text-gray-700">{memberZone}</span>
+                </p>
+              )}
+            </IonLabel>
+          </IonItem>
+        )}
         <IonItem>
           <IonLabel position="stacked">Foto del acta</IonLabel>
-          
+
         </IonItem>
         <div className="flex flex-col items-center gap-4  w-4/5 mx-auto mt-4">
           <Button onClick={handleFoto} className="flex flex-col items-center w-4/5">

--- a/src/pages/FiscalizacionLookup.tsx
+++ b/src/pages/FiscalizacionLookup.tsx
@@ -3,7 +3,7 @@ import { IonContent, IonItem, IonLabel, useIonViewWillEnter } from '@ionic/react
 import { useHistory } from 'react-router-dom';
 import Layout from '../components/Layout';
 import { Button, Input } from '../components';
-import { useFiscalData } from '../FiscalDataContext';
+import { normalizeFiscalData, useFiscalData } from '../FiscalDataContext';
 import type { FiscalData } from '../FiscalDataContext';
 
 // ================== Configuración de API ==================
@@ -97,6 +97,12 @@ const FiscalizacionLookup: React.FC = () => {
         { Authorization: `Bearer ${token}` }
       );
 
+      console.log('[FiscalizacionLookup] buscarFiscal response', {
+        status: r.status,
+        ok: r.ok,
+        payload: r.payload,
+      });
+
       // si el backend acepta token "pelado", reintentar
       if (!r.ok && r.status === 401) {
         const retry = await postJson(
@@ -104,6 +110,12 @@ const FiscalizacionLookup: React.FC = () => {
           { dni_miembro: dniNum },
           { Authorization: token }
         );
+
+        console.log('[FiscalizacionLookup] buscarFiscal retry response', {
+          status: retry.status,
+          ok: retry.ok,
+          payload: retry.payload,
+        });
         if (!retry.ok) {
           const msg =
             typeof retry.payload === 'string'
@@ -112,10 +124,11 @@ const FiscalizacionLookup: React.FC = () => {
           throw new Error(msg);
         }
         const fiscal = retry.payload as FiscalData;
-        setResult(fiscal);
-        localStorage.setItem('fiscalData', JSON.stringify(fiscal));
-        setFiscalData(fiscal);
-        history.push('/fiscalizacion-acciones', { fiscalData: fiscal });
+        const normalizedFiscal = normalizeFiscalData(fiscal) ?? fiscal;
+        setResult(normalizedFiscal);
+        localStorage.setItem('fiscalData', JSON.stringify(normalizedFiscal));
+        setFiscalData(normalizedFiscal);
+        history.push('/fiscalizacion-acciones', { fiscalData: normalizedFiscal });
         return;
       }
 
@@ -129,10 +142,11 @@ const FiscalizacionLookup: React.FC = () => {
 
       // OK
       const fiscal = r.payload as FiscalData;
-      setResult(fiscal);
-      localStorage.setItem('fiscalData', JSON.stringify(fiscal));
-      setFiscalData(fiscal);
-      history.push('/fiscalizacion-acciones', { fiscalData: fiscal });
+      const normalizedFiscal = normalizeFiscalData(fiscal) ?? fiscal;
+      setResult(normalizedFiscal);
+      localStorage.setItem('fiscalData', JSON.stringify(normalizedFiscal));
+      setFiscalData(normalizedFiscal);
+      history.push('/fiscalizacion-acciones', { fiscalData: normalizedFiscal });
 
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'DNI no registrado';


### PR DESCRIPTION
## Summary
- ensure FiscalData normalization surfaces nested persona and identification fields returned by buscarFiscal
- store the normalized fiscal data when saving lookup results for the actions screen so member details render immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c107d1fc83298ac9655ee1c6bd74