### PR TITLE
Display fiscal assignment metadata

### DIFF
--- a/src/FiscalDataContext.test.tsx
+++ b/src/FiscalDataContext.test.tsx
@@ -5,6 +5,7 @@ import {
   FiscalDataProvider,
   useFiscalData,
   type FiscalData,
+  getFiscalAssignmentDetails,
 } from './FiscalDataContext';
 
 const Consumer: React.FC = () => {
@@ -76,5 +77,33 @@ describe('FiscalDataProvider hydration', () => {
       expect(parsed.nombre_tipo_miembro).toBe('Suplente');
       expect(parsed.nombre_zona).toBe('Zona 9');
     });
+  });
+});
+
+describe('getFiscalAssignmentDetails', () => {
+  it('returns values from direct fields', () => {
+    const payload: FiscalData = {
+      mesa: '1234',
+      lugar: 'Escuela Primaria 1',
+      fiscal_general: 'Juan Pérez',
+    };
+
+    const result = getFiscalAssignmentDetails(payload);
+    expect(result.mesa).toBe('1234');
+    expect(result.lugar).toBe('Escuela Primaria 1');
+    expect(result.fiscalGeneral).toBe('Juan Pérez');
+  });
+
+  it('extracts nested values when necessary', () => {
+    const payload: FiscalData = {
+      establecimiento: { nombre: 'Colegio Nacional', direccion: 'Calle Falsa 123' },
+      mesa_asignada: { numero: '4321' },
+      fiscalGeneral: { nombre: 'María López' },
+    };
+
+    const result = getFiscalAssignmentDetails(payload);
+    expect(result.mesa).toBe('4321');
+    expect(result.lugar).toBe('Colegio Nacional');
+    expect(result.fiscalGeneral).toBe('María López');
   });
 });

--- a/src/FiscalDataContext.tsx
+++ b/src/FiscalDataContext.tsx
@@ -44,6 +44,85 @@ const NAME_FIELD_KEYS = [
 ];
 
 const METADATA_FIELD_KEYS = ['nombre_tipo_miembro', 'tipo_fiscal', 'nombre_zona', 'zona'];
+const FISCAL_GENERAL_FIELD_KEYS = [
+  'fiscal_general',
+  'nombre_fiscal_general',
+  'fiscalGeneral',
+  'fiscal_general_nombre',
+] as const;
+const MESA_FIELD_KEYS = [
+  'mesa',
+  'mesa_asignada',
+  'mesa_id',
+  'numero_mesa',
+  'mesa_numero',
+  'mesaNumero',
+] as const;
+const LOCATION_FIELD_KEYS = [
+  'lugar',
+  'lugar_fiscalizacion',
+  'nombre_lugar',
+  'nombre_establecimiento',
+  'establecimiento',
+  'nombre_establecimiento_educativo',
+  'ubicacion',
+  'direccion',
+] as const;
+const NESTED_STRING_KEYS = [
+  'nombre',
+  'name',
+  'descripcion',
+  'description',
+  'direccion',
+  'ubicacion',
+  'lugar',
+] as const;
+
+const extractStringValue = (value: unknown): string | undefined => {
+  const direct = getTrimmedString(value);
+  if (direct) return direct;
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = extractStringValue(item);
+      if (nested) return nested;
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const key of NESTED_STRING_KEYS) {
+    if (key in value) {
+      const nested = extractStringValue(value[key]);
+      if (nested) return nested;
+    }
+  }
+
+  for (const nested of Object.values(value)) {
+    const nestedValue = extractStringValue(nested);
+    if (nestedValue) return nestedValue;
+  }
+
+  return undefined;
+};
+
+const getFirstMatchingField = (
+  source: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined => {
+  for (const key of keys) {
+    if (key in source) {
+      const value = extractStringValue(source[key]);
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+};
 
 const findNestedPersona = (value: unknown): Record<string, unknown> | undefined => {
   if (Array.isArray(value)) {
@@ -236,6 +315,22 @@ export const normalizeFiscalData = (value: unknown): FiscalData | null => {
   }
 
   return normalized as FiscalData;
+};
+
+export const getFiscalAssignmentDetails = (
+  data?: FiscalData | null,
+): { mesa?: string; lugar?: string; fiscalGeneral?: string } => {
+  if (!data) {
+    return {};
+  }
+
+  const record = data as Record<string, unknown>;
+
+  return {
+    mesa: getFirstMatchingField(record, MESA_FIELD_KEYS),
+    lugar: getFirstMatchingField(record, LOCATION_FIELD_KEYS),
+    fiscalGeneral: getFirstMatchingField(record, FISCAL_GENERAL_FIELD_KEYS),
+  };
 };
 
 interface FiscalDataContextValue {

--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -1,7 +1,7 @@
 import { IonContent, IonItem, IonLabel } from '@ionic/react';
 import Layout from '../components/Layout';
 import { Button } from '../components';
-import { getMemberNameParts, useFiscalData } from '../FiscalDataContext';
+import { getFiscalAssignmentDetails, getMemberNameParts, useFiscalData } from '../FiscalDataContext';
 import type { FiscalData } from '../FiscalDataContext';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -36,6 +36,36 @@ const FiscalizacionActions: React.FC = () => {
     const value = typeof fiscalData.nombre_zona === 'string' ? fiscalData.nombre_zona.trim() : '';
     return value;
   }, [fiscalData]);
+
+  const { mesa: mesaAsignadaDesdeData, lugar: lugarAsignadoDesdeData, fiscalGeneral } = useMemo(
+    () => getFiscalAssignmentDetails(fiscalData ?? undefined),
+    [fiscalData],
+  );
+
+  const mesaAsignada = useMemo(() => {
+    if (mesaAsignadaDesdeData) return mesaAsignadaDesdeData;
+    if (typeof window === 'undefined') return undefined;
+    const storedMesa = localStorage.getItem('mesa');
+    return storedMesa?.trim() ? storedMesa.trim() : undefined;
+  }, [mesaAsignadaDesdeData]);
+
+  const lugarAsignado = useMemo(() => {
+    if (lugarAsignadoDesdeData) return lugarAsignadoDesdeData;
+    if (typeof window === 'undefined') return undefined;
+    const storedEstablecimiento = localStorage.getItem('establecimiento');
+    if (storedEstablecimiento?.trim()) return storedEstablecimiento.trim();
+
+    const seccion = localStorage.getItem('seccion')?.trim();
+    const circuito = localStorage.getItem('circuito')?.trim();
+    const parts = [seccion ? `Sección ${seccion}` : null, circuito ? `Circuito ${circuito}` : null]
+      .filter(Boolean)
+      .join(' · ');
+
+    return parts || undefined;
+  }, [lugarAsignadoDesdeData]);
+
+  const metadataLabelClass = 'text-sm text-gray-600';
+  const metadataValueClass = 'font-medium text-gray-700';
 
   const handleFoto = async () => {
     try {
@@ -92,10 +122,31 @@ const FiscalizacionActions: React.FC = () => {
             <IonLabel>
               <h2 className="font-semibold text-base">Fiscal asignado</h2>
               {memberName && <p className="text-sm">{memberName}</p>}
-              {memberType && <p className="text-sm text-gray-600">{memberType}</p>}
+              {memberType && (
+                <p className={metadataLabelClass}>
+                  Tipo de fiscal:{' '}
+                  <span className={metadataValueClass}>{memberType}</span>
+                </p>
+              )}
+              {mesaAsignada && (
+                <p className={metadataLabelClass}>
+                  Mesa: <span className={metadataValueClass}>{mesaAsignada}</span>
+                </p>
+              )}
+              {lugarAsignado && (
+                <p className={metadataLabelClass}>
+                  Lugar: <span className={metadataValueClass}>{lugarAsignado}</span>
+                </p>
+              )}
               {memberZone && (
-                <p className="text-sm text-gray-600">
-                  Zona: <span className="font-medium text-gray-700">{memberZone}</span>
+                <p className={metadataLabelClass}>
+                  Zona: <span className={metadataValueClass}>{memberZone}</span>
+                </p>
+              )}
+              {fiscalGeneral && (
+                <p className={metadataLabelClass}>
+                  Fiscal general:{' '}
+                  <span className={metadataValueClass}>{fiscalGeneral}</span>
                 </p>
               )}
             </IonLabel>


### PR DESCRIPTION
## Summary
- add utilities to extract mesa, lugar and fiscal general metadata from fiscal data
- render the additional fiscal assignment details in the fiscal actions screen with sensible fallbacks
- cover the new helper logic with unit tests

## Testing
- npm run test.unit -- src/FiscalDataContext.test.tsx
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e317b568e48329b7061d5ccfa9781c