### PR TITLE
Include escuela name and address in fiscal actions screen

### DIFF
--- a/src/FiscalDataContext.test.tsx
+++ b/src/FiscalDataContext.test.tsx
@@ -5,6 +5,7 @@ import {
   FiscalDataProvider,
   useFiscalData,
   type FiscalData,
+  getFiscalAssignmentDetails,
 } from './FiscalDataContext';
 
 const Consumer: React.FC = () => {
@@ -76,5 +77,49 @@ describe('FiscalDataProvider hydration', () => {
       expect(parsed.nombre_tipo_miembro).toBe('Suplente');
       expect(parsed.nombre_zona).toBe('Zona 9');
     });
+  });
+});
+
+describe('getFiscalAssignmentDetails', () => {
+  it('returns values from direct fields', () => {
+    const payload: FiscalData = {
+      mesa: '1234',
+      nombre_escuela: 'Escuela Primaria 1',
+      direccion_escuela: 'Calle Principal 456',
+      fiscal_general: 'Juan Pérez',
+    };
+
+    const result = getFiscalAssignmentDetails(payload);
+    expect(result.mesa).toBe('1234');
+    expect(result.establecimiento).toBe('Escuela Primaria 1');
+    expect(result.direccion).toBe('Calle Principal 456');
+    expect(result.fiscalGeneral).toBe('Juan Pérez');
+  });
+
+  it('extracts nested values when necessary', () => {
+    const payload: FiscalData = {
+      establecimiento: { nombre: 'Colegio Nacional', direccion: 'Calle Falsa 123' },
+      mesa_asignada: { numero: '4321' },
+      fiscalGeneral: { nombre: 'María López' },
+    };
+
+    const result = getFiscalAssignmentDetails(payload);
+    expect(result.mesa).toBe('4321');
+    expect(result.establecimiento).toBe('Colegio Nacional');
+    expect(result.direccion).toBe('Calle Falsa 123');
+    expect(result.fiscalGeneral).toBe('María López');
+  });
+
+  it('prefers escuela specific keys when available', () => {
+    const payload: FiscalData = {
+      escuela: { descripcion: 'Escuela Secundaria 12' },
+      direccionEscuela: 'Av. Siempre Viva 742',
+      lugar: 'Polideportivo Municipal',
+    };
+
+    const result = getFiscalAssignmentDetails(payload);
+    expect(result.establecimiento).toBe('Escuela Secundaria 12');
+    expect(result.direccion).toBe('Av. Siempre Viva 742');
+    expect(result.lugar).toBe('Polideportivo Municipal');
   });
 });

--- a/src/FiscalDataContext.tsx
+++ b/src/FiscalDataContext.tsx
@@ -44,6 +44,116 @@ const NAME_FIELD_KEYS = [
 ];
 
 const METADATA_FIELD_KEYS = ['nombre_tipo_miembro', 'tipo_fiscal', 'nombre_zona', 'zona'];
+const FISCAL_GENERAL_FIELD_KEYS = [
+  'fiscal_general',
+  'nombre_fiscal_general',
+  'fiscalGeneral',
+  'fiscal_general_nombre',
+] as const;
+const MESA_FIELD_KEYS = [
+  'mesa',
+  'mesa_asignada',
+  'mesa_id',
+  'numero_mesa',
+  'mesa_numero',
+  'mesaNumero',
+] as const;
+const ESTABLECIMIENTO_FIELD_KEYS = [
+  'nombre_establecimiento',
+  'nombre_establecimiento_educativo',
+  'nombre_establecimiento_fiscalizacion',
+  'nombre_escuela',
+  'nombreEscuela',
+  'escuela',
+  'establecimiento',
+  'nombre_lugar',
+  'lugar',
+] as const;
+const DIRECCION_FIELD_KEYS = [
+  'direccion_establecimiento',
+  'direccion_establecimiento_educativo',
+  'direccion_establecimiento_fiscalizacion',
+  'direccion_escuela',
+  'direccionEscuela',
+  'direccion',
+  'domicilio',
+  'ubicacion',
+  'direccion_lugar',
+] as const;
+const LUGAR_FIELD_KEYS = [
+  'lugar',
+  'lugar_fiscalizacion',
+  'nombre_lugar',
+  'ubicacion',
+] as const;
+const NESTED_STRING_KEYS = [
+  'nombre',
+  'name',
+  'descripcion',
+  'description',
+  'direccion',
+  'ubicacion',
+  'lugar',
+] as const;
+
+const extractStringValue = (
+  value: unknown,
+  preferredNestedKeys?: readonly string[],
+): string | undefined => {
+  const direct = getTrimmedString(value);
+  if (direct) return direct;
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = extractStringValue(item, preferredNestedKeys);
+      if (nested) return nested;
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (preferredNestedKeys) {
+    for (const key of preferredNestedKeys) {
+      if (key in value) {
+        const nested = extractStringValue(value[key], preferredNestedKeys);
+        if (nested) return nested;
+      }
+    }
+  }
+
+  for (const key of NESTED_STRING_KEYS) {
+    if (key in value) {
+      const nested = extractStringValue(value[key], preferredNestedKeys);
+      if (nested) return nested;
+    }
+  }
+
+  for (const nested of Object.values(value)) {
+    const nestedValue = extractStringValue(nested, preferredNestedKeys);
+    if (nestedValue) return nestedValue;
+  }
+
+  return undefined;
+};
+
+const getFirstMatchingField = (
+  source: Record<string, unknown>,
+  keys: readonly string[],
+  preferredNestedKeys?: readonly string[],
+): string | undefined => {
+  for (const key of keys) {
+    if (key in source) {
+      const value = extractStringValue(source[key], preferredNestedKeys);
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return undefined;
+};
 
 const findNestedPersona = (value: unknown): Record<string, unknown> | undefined => {
   if (Array.isArray(value)) {
@@ -236,6 +346,56 @@ export const normalizeFiscalData = (value: unknown): FiscalData | null => {
   }
 
   return normalized as FiscalData;
+};
+
+export const getFiscalAssignmentDetails = (
+  data?: FiscalData | null,
+): {
+  mesa?: string;
+  lugar?: string;
+  establecimiento?: string;
+  direccion?: string;
+  fiscalGeneral?: string;
+} => {
+  if (!data) {
+    return {};
+  }
+
+  const record = data as Record<string, unknown>;
+
+  const establecimiento = getFirstMatchingField(
+    record,
+    ESTABLECIMIENTO_FIELD_KEYS,
+    ['nombre', 'name', 'descripcion', 'description', 'lugar'],
+  );
+
+  const direccion =
+    getFirstMatchingField(record, DIRECCION_FIELD_KEYS, [
+      'direccion',
+      'domicilio',
+      'ubicacion',
+      'address',
+      'calle',
+    ]) ||
+    (typeof record['establecimiento'] === 'object' &&
+    record['establecimiento'] !== null &&
+    !Array.isArray(record['establecimiento'])
+      ? getFirstMatchingField(record['establecimiento'] as Record<string, unknown>, ['direccion', 'domicilio', 'ubicacion'], [
+          'direccion',
+          'domicilio',
+          'ubicacion',
+          'address',
+          'calle',
+        ])
+      : undefined);
+
+  return {
+    mesa: getFirstMatchingField(record, MESA_FIELD_KEYS),
+    lugar: getFirstMatchingField(record, LUGAR_FIELD_KEYS),
+    establecimiento,
+    direccion,
+    fiscalGeneral: getFirstMatchingField(record, FISCAL_GENERAL_FIELD_KEYS),
+  };
 };
 
 interface FiscalDataContextValue {

--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -1,9 +1,13 @@
 import { IonContent, IonItem, IonLabel } from '@ionic/react';
 import Layout from '../components/Layout';
 import { Button } from '../components';
-import { getMemberNameParts, useFiscalData } from '../FiscalDataContext';
+import {
+  getFiscalAssignmentDetails,
+  getMemberNameParts,
+  useFiscalData,
+} from '../FiscalDataContext';
 import type { FiscalData } from '../FiscalDataContext';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Camera, CameraResultType } from '@capacitor/camera';
 import type { ChangeEvent } from 'react';
@@ -36,6 +40,138 @@ const FiscalizacionActions: React.FC = () => {
     const value = typeof fiscalData.nombre_zona === 'string' ? fiscalData.nombre_zona.trim() : '';
     return value;
   }, [fiscalData]);
+
+  const {
+    mesa: mesaAsignadaDesdeData,
+    lugar: lugarAsignadoDesdeData,
+    establecimiento: establecimientoDesdeData,
+    direccion: direccionDesdeData,
+    fiscalGeneral,
+  } = useMemo(
+    () => getFiscalAssignmentDetails(fiscalData ?? undefined),
+    [fiscalData],
+  );
+
+  const readStoredAssignmentValue = useCallback(
+    (keys: string[], preferredNestedKeys: readonly string[]): string | undefined => {
+      for (const key of keys) {
+        const raw = localStorage.getItem(key);
+        if (!raw) continue;
+
+        const trimmed = raw.trim();
+        if (!trimmed) {
+          continue;
+        }
+
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (typeof parsed === 'string') {
+            const value = parsed.trim();
+            if (value) {
+              return value;
+            }
+          } else if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            const parsedRecord = parsed as Record<string, unknown>;
+            for (const nestedKey of preferredNestedKeys) {
+              const value = parsedRecord[nestedKey];
+              if (typeof value === 'string') {
+                const nestedTrimmed = value.trim();
+                if (nestedTrimmed) {
+                  return nestedTrimmed;
+                }
+              }
+            }
+
+            for (const value of Object.values(parsedRecord)) {
+              if (typeof value === 'string') {
+                const nestedTrimmed = value.trim();
+                if (nestedTrimmed) {
+                  return nestedTrimmed;
+                }
+              }
+            }
+          }
+        } catch {
+          // Not JSON, fall back to returning the trimmed string below.
+        }
+
+        return trimmed;
+      }
+
+      return undefined;
+    },
+    [],
+  );
+
+  const mesaAsignada = useMemo(() => {
+    if (mesaAsignadaDesdeData) return mesaAsignadaDesdeData;
+    if (typeof window === 'undefined') return undefined;
+    const storedMesa = localStorage.getItem('mesa');
+    return storedMesa?.trim() ? storedMesa.trim() : undefined;
+  }, [mesaAsignadaDesdeData]);
+
+  const establecimientoAsignado = useMemo(() => {
+    if (establecimientoDesdeData) return establecimientoDesdeData;
+    if (typeof window === 'undefined') return undefined;
+
+    return readStoredAssignmentValue(
+      [
+        'nombre_establecimiento',
+        'nombreEstablecimiento',
+        'nombre_establecimiento_fiscalizacion',
+        'nombre_escuela',
+        'nombreEscuela',
+        'escuela',
+        'establecimiento',
+        'lugar',
+      ],
+      ['nombre', 'name', 'descripcion', 'description', 'lugar'],
+    );
+  }, [establecimientoDesdeData, readStoredAssignmentValue]);
+
+  const direccionAsignada = useMemo(() => {
+    if (direccionDesdeData) return direccionDesdeData;
+    if (typeof window === 'undefined') return undefined;
+
+    const fallback = readStoredAssignmentValue(
+      [
+        'direccion_establecimiento',
+        'direccionEstablecimiento',
+        'direccion_establecimiento_fiscalizacion',
+        'direccion_escuela',
+        'direccionEscuela',
+        'direccion',
+        'domicilio',
+        'ubicacion',
+        'establecimiento',
+      ],
+      ['direccion', 'domicilio', 'ubicacion', 'address', 'calle'],
+    );
+
+    if (fallback) {
+      return fallback;
+    }
+
+    const seccion = localStorage.getItem('seccion')?.trim();
+    const circuito = localStorage.getItem('circuito')?.trim();
+    const parts = [seccion ? `Sección ${seccion}` : null, circuito ? `Circuito ${circuito}` : null]
+      .filter(Boolean)
+      .join(' · ');
+
+    return parts || undefined;
+  }, [direccionDesdeData, readStoredAssignmentValue]);
+
+  const lugarAsignado = useMemo(() => {
+    if (lugarAsignadoDesdeData) return lugarAsignadoDesdeData;
+    if (typeof window === 'undefined') return undefined;
+    const storedLugar = localStorage.getItem('lugar');
+    if (storedLugar?.trim()) return storedLugar.trim();
+
+    return establecimientoAsignado || undefined;
+  }, [establecimientoAsignado, lugarAsignadoDesdeData]);
+
+  const metadataLabelClass = 'text-sm text-gray-600';
+  const metadataValueClass = 'font-medium text-gray-700';
 
   const handleFoto = async () => {
     try {
@@ -92,10 +228,47 @@ const FiscalizacionActions: React.FC = () => {
             <IonLabel>
               <h2 className="font-semibold text-base">Fiscal asignado</h2>
               {memberName && <p className="text-sm">{memberName}</p>}
-              {memberType && <p className="text-sm text-gray-600">{memberType}</p>}
+              {memberType && (
+                <p className={metadataLabelClass}>
+                  Tipo de fiscal:{' '}
+                  <span className={metadataValueClass}>{memberType}</span>
+                </p>
+              )}
+              {mesaAsignada && (
+                <p className={metadataLabelClass}>
+                  Mesa: <span className={metadataValueClass}>{mesaAsignada}</span>
+                </p>
+              )}
+              {establecimientoAsignado && (
+                <p className={metadataLabelClass}>
+                  Escuela:{' '}
+                  <span className={metadataValueClass}>{establecimientoAsignado}</span>
+                </p>
+              )}
+              {direccionAsignada && (
+                <p className={metadataLabelClass}>
+                  Dirección: <span className={metadataValueClass}>{direccionAsignada}</span>
+                </p>
+              )}
+              {lugarAsignado && (!establecimientoAsignado || lugarAsignado !== establecimientoAsignado) && (
+                <p className={metadataLabelClass}>
+                  Lugar: <span className={metadataValueClass}>{lugarAsignado}</span>
+                </p>
+              )}
               {memberZone && (
-                <p className="text-sm text-gray-600">
-                  Zona: <span className="font-medium text-gray-700">{memberZone}</span>
+                <p className={metadataLabelClass}>
+                  Zona: <span className={metadataValueClass}>{memberZone}</span>
+                </p>
+              )}
+              {fiscalGeneral && (
+                <p className={metadataLabelClass}>
+                  Fiscal general:{' '}
+                  <span className={metadataValueClass}>{fiscalGeneral}</span>
+                </p>
+              )}
+              {(establecimientoAsignado || direccionAsignada) && (
+                <p className="text-xs italic text-gray-500 mt-2">
+                  Sugerencia: agregá un mapa del establecimiento para facilitar la ubicación en el territorio.
                 </p>
               )}
             </IonLabel>


### PR DESCRIPTION
## Summary
- broaden the fiscal assignment extractor to recognize escuela-specific name and address keys
- look up escuela and direccion assignments from cached values and label the display accordingly in the fiscalization screen
- extend unit coverage to ensure escuela-focused fields are surfaced by the helper

## Testing
- npm run test.unit -- src/FiscalDataContext.test.tsx
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e317b568e48329b7061d5ccfa9781c