### PR TITLE
Guard mesa number extraction recursion

### DIFF
--- a/src/pages/FiscalizacionActions.tsx
+++ b/src/pages/FiscalizacionActions.tsx
@@ -453,9 +453,18 @@ const extractMesaNumero = (
       }
     }
   }
-  console.log(extractMesaNumero(record))
-  if ('mesa_asignada' in record && isRecord(record['mesa_asignada'])) {
-    const nested = extractMesaNumero(record['mesa_asignada'], visited);
+  const extraMesaSources = [
+    record['mesa_asignada'],
+    record['mesaAsignada'],
+    record['mesa_asignado'],
+    record['mesaAsignado'],
+  ];
+
+  for (const source of extraMesaSources) {
+    if (!source || typeof source !== 'object' || visited.has(source)) continue;
+    visited.add(source);
+    if (!isRecord(source)) continue;
+    const nested = extractMesaNumero(source, visited);
     if (nested) return nested;
   }
 
@@ -1432,24 +1441,6 @@ const FiscalizacionActions: React.FC = () => {
   const establecimientosAsignados = useMemo(
     () => extractEstablecimientos(fiscalData ?? undefined),
     [fiscalData],
-  );
-  const fiscalGeneralContact = useMemo(
-    () => extractRoleContact(fiscalData ?? undefined, FISCAL_GENERAL_CONTACT_CONFIG),
-    [fiscalData],
-  );
-  const fiscalZonalContact = useMemo(
-    () => extractRoleContact(fiscalData ?? undefined, FISCAL_ZONAL_CONTACT_CONFIG),
-    [fiscalData],
-  );
-
-  const shouldShowFiscalGeneralContact = useMemo(
-    () => Boolean(fiscalGeneralContact) && !isFiscalGeneral && !isFiscalZonal,
-    [fiscalGeneralContact, isFiscalGeneral, isFiscalZonal],
-  );
-
-  const shouldShowFiscalZonalContact = useMemo(
-    () => Boolean(fiscalZonalContact) && !isFiscalZonal,
-    [fiscalZonalContact, isFiscalZonal],
   );
   const fiscalGeneralContact = useMemo(
     () => extractRoleContact(fiscalData ?? undefined, FISCAL_GENERAL_CONTACT_CONFIG),


### PR DESCRIPTION
## Summary
- avoid re-invoking `extractMesaNumero` with the same record by removing the stray debug call
- guard alternate mesa assignment objects with the visited set to prevent infinite recursion while searching nested data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f68905d1ac83299d563f5515d83257