### PR TITLE
Add vote stepper controls to escrutinio inputs

### DIFF
--- a/src/components/NumericStepperInput.tsx
+++ b/src/components/NumericStepperInput.tsx
@@ -1,0 +1,133 @@
+import React, { useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import { IonButton } from '@ionic/react';
+import type { InputCustomEvent, InputChangeEventDetail } from '@ionic/react';
+import Input, { InputProps } from './Input';
+
+export type NumericStepperInputProps = {
+  value?: string;
+  onValueChange: (value: string) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  placeholder?: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+  inputProps?: Omit<InputProps, 'value' | 'onIonChange' | 'placeholder'>;
+};
+
+const clamp = (value: number, min?: number, max?: number) => {
+  let next = value;
+  if (typeof min === 'number') {
+    next = Math.max(min, next);
+  }
+  if (typeof max === 'number') {
+    next = Math.min(max, next);
+  }
+  return next;
+};
+
+const parseNumericValue = (value?: string) => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const NumericStepperInput: React.FC<NumericStepperInputProps> = ({
+  value = '',
+  onValueChange,
+  min = 0,
+  max,
+  step = 1,
+  placeholder,
+  ariaLabel,
+  disabled = false,
+  inputProps,
+}) => {
+  const sanitizedStep = step > 0 ? step : 1;
+
+  const currentNumber = useMemo(() => parseNumericValue(value), [value]);
+  const effectiveCurrent = useMemo(() => {
+    if (typeof currentNumber === 'number') {
+      return currentNumber;
+    }
+    return typeof min === 'number' ? min : 0;
+  }, [currentNumber, min]);
+
+  const handleInputChange = (event: InputCustomEvent<InputChangeEventDetail>) => {
+    onValueChange(event.detail.value ?? '');
+  };
+
+  const handleStep = (delta: number) => {
+    const base = typeof currentNumber === 'number' ? currentNumber : effectiveCurrent;
+    const nextValue = clamp(base + delta * sanitizedStep, min, max);
+    onValueChange(`${nextValue}`);
+  };
+
+  const decrementDisabled = disabled || (typeof min === 'number' && effectiveCurrent <= min);
+  const incrementDisabled =
+    disabled ||
+    (typeof max === 'number' &&
+      (typeof currentNumber === 'number' ? currentNumber >= max : effectiveCurrent >= max));
+
+  const { className = '', style, ...restInputProps } = inputProps ?? {};
+
+  const mergedStyle: CSSProperties = {
+    flex: 1,
+    width: '100%',
+    ...style,
+  };
+
+  const buttonStyle = {
+    '--border-radius': '9999px',
+    minWidth: '2.5rem',
+    height: '2.5rem',
+  } as CSSProperties;
+
+  return (
+    <div className="flex items-center gap-2 w-full">
+      <IonButton
+        type="button"
+        fill="outline"
+        color="medium"
+        size="small"
+        onClick={() => handleStep(-1)}
+        disabled={decrementDisabled}
+        style={buttonStyle}
+      >
+        −
+      </IonButton>
+      <Input
+        value={value}
+        onIonChange={handleInputChange}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        inputmode="numeric"
+        type="number"
+        className={`flex-1 ${className}`}
+        style={mergedStyle}
+        disabled={disabled}
+        {...restInputProps}
+      />
+      <IonButton
+        type="button"
+        fill="outline"
+        color="medium"
+        size="small"
+        onClick={() => handleStep(1)}
+        disabled={incrementDisabled}
+        style={buttonStyle}
+      >
+        +
+      </IonButton>
+    </div>
+  );
+};
+
+export default NumericStepperInput;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as Button } from './Button';
 export { default as Input } from './Input';
 export { default as Card } from './Card';
 export { default as FooterBar } from './FooterBar';
+export { default as NumericStepperInput } from './NumericStepperInput';

--- a/src/pages/Escrutinio.tsx
+++ b/src/pages/Escrutinio.tsx
@@ -12,7 +12,7 @@ import {
   IonCardHeader,
   IonCardTitle,
 } from '@ionic/react';
-import { Button, Input } from '../components';
+import { Button, Input, NumericStepperInput } from '../components';
 import Layout from '../components/Layout';
 import { useHistory } from 'react-router-dom';
 import {
@@ -925,43 +925,43 @@ const Gap: React.FC<{ h?: number }> = ({ h = 8 }) => <div style={{ height: h }} 
 
         {/* Cards por lista */}
         {listas.map((l) => (
-  <IonCard
-    key={l.id}
-    className="text-20xl ion-margin-bottom shadow-sm border border-solid border-gray-200"
-  >
-    <IonCardHeader className="pb-0">
-      {/* Cabecera con nombre a la izquierda y número a la derecha */}
-      <div className="text-1xl flex items-start justify-between items-center">
-        <div>
-          <IonCardTitle className="text-xl font-semibold text-gray-900 leading-tight">
-            {l.numeroLista} - {l.lista}
-          </IonCardTitle>
-          {l.sigla && (
-            <IonNote
-              color="medium"
-              className="mt-1 block text-sm text-gray-600 uppercase tracking-wide"
-            >
-              {l.sigla}
-            </IonNote>
-          )}
-        </div>
+          <IonCard
+            key={l.id}
+            className="text-20xl ion-margin-bottom shadow-sm border border-solid border-gray-200"
+          >
+            <IonCardHeader className="pb-0">
+              {/* Cabecera con nombre a la izquierda y número a la derecha */}
+              <div className="text-1xl flex items-start justify-between items-center">
+                <div>
+                  <IonCardTitle className="text-xl font-semibold text-gray-900 leading-tight">
+                    {l.numeroLista} - {l.lista}
+                  </IonCardTitle>
+                  {l.sigla && (
+                    <IonNote
+                      color="medium"
+                      className="mt-1 block text-sm text-gray-600 uppercase tracking-wide"
+                    >
+                      {l.sigla}
+                    </IonNote>
+                  )}
+                </div>
+              </div>
+            </IonCardHeader>
 
-      </div>
-    </IonCardHeader>
-
-    <IonCardContent className="pt-4">
-      <IonItem lines="none" className="form-field ion-no-padding">
-        <Input
-          type="number"
-          value={valores[l.id] || ''}
-          onIonChange={(e) => handleChange(l.id, e.detail.value ?? '')}
-          placeholder="Cantidad de votos"
-          aria-label={`Cantidad de votos para ${l.lista}`}
-        />
-      </IonItem>
-    </IonCardContent>
-  </IonCard>
-))}
+            <IonCardContent className="pt-4">
+              <IonItem lines="none" className="form-field ion-no-padding">
+                <div className="w-full">
+                  <NumericStepperInput
+                    value={valores[l.id] || ''}
+                    onValueChange={(nextValue) => handleChange(l.id, nextValue)}
+                    placeholder="Cantidad de votos"
+                    ariaLabel={`Cantidad de votos para ${l.lista}`}
+                  />
+                </div>
+              </IonItem>
+            </IonCardContent>
+          </IonCard>
+        ))}
 
 
         {/* Campos especiales: se dejan igual */}
@@ -971,17 +971,17 @@ const Gap: React.FC<{ h?: number }> = ({ h = 8 }) => <div style={{ height: h }} 
               {ESPECIALES_DETALLE[key].nombre}
             </IonLabel>
             <div style={{ height: 6 }} />
-            <Input
-              type="number"
+            <NumericStepperInput
               value={valores[key] || ''}
-              onIonChange={(e) => handleChange(key, e.detail.value ?? '')}
+              onValueChange={(nextValue) => handleChange(key, nextValue)}
               placeholder={`Cantidad - ${ESPECIALES_DETALLE[key].nombre}`}
+              ariaLabel={`Cantidad de votos para ${ESPECIALES_DETALLE[key].nombre}`}
             />
           </IonItem>
         ))}
 
         <Button
-        style={{ paddingBottom: '120px' }}
+          style={{ paddingBottom: '120px' }}
           expand="block"
           className="ion-margin-top"
           onClick={handleSubmit}


### PR DESCRIPTION
## Summary
- add a reusable numeric stepper input component with +/- controls
- use the stepper for vote entry fields in the escrutinio view and special totals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe7bef636c83299d4dcc03db50572e